### PR TITLE
Give an age and batch size to the staging update_index

### DIFF
--- a/scripts/chicago-staging-crontasks
+++ b/scripts/chicago-staging-crontasks
@@ -1,4 +1,4 @@
 # /etc/cron.d/chicago-staging-crontasks
 APPDIR=/home/datamade/chicago-staging
 PYTHONDIR=/home/datamade/.virtualenvs/chicago-staging/bin/python
-0 5 * * * datamade cd $APPDIR && $PYTHONDIR manage.py import_data >> /tmp/chicago-staging-loaddata.log 2>&1 && $PYTHONDIR manage.py update_index >> /tmp/chicago-staging-updateindex.log
+0 5 * * * datamade cd $APPDIR && $PYTHONDIR manage.py import_data >> /tmp/chicago-staging-loaddata.log 2>&1 && $PYTHONDIR manage.py update_index --batch-size=100 --age=24 >> /tmp/chicago-staging-updateindex.log


### PR DESCRIPTION
This PR deals with the first second checkbox in this meta-issue: datamade/django-councilmatic#182