### PR TITLE
Use prepared data, rather than the object last action date, to determine boost

### DIFF
--- a/chicago/search_indexes.py
+++ b/chicago/search_indexes.py
@@ -22,11 +22,13 @@ class ChicagoBillIndex(BillIndex, indexes.Indexable):
         data = super(ChicagoBillIndex, self).prepare(obj)
 
         boost = 0
-        if obj.last_action_date:
-            now = app_timezone.localize(datetime.now())
 
-            # obj.last_action_date can be in the future
-            weeks_passed = (now - obj.last_action_date).days / 7 + 1
+        if data['last_action_date']:
+            today = app_timezone.localize(datetime.now()).date()
+
+            # data['last_action_date'] can be in the future
+            weeks_passed = (today - data['last_action_date']).days / 7 + 1
+
             boost = 1 + 1.0 / max(weeks_passed, 1)
 
         data['boost'] = boost


### PR DESCRIPTION
## Description

This PR is a continuation of #267. It uses the prepared last action date to calculate boost, closing https://sentry.io/organizations/datamade/issues/1833078105/.

Handles #265.

## Testing instructions

- Build the Solr index and confirm nothing breaks: `docker-compose run --rm app python manage.py update_index`