### PR TITLE
Fix production crontask

### DIFF
--- a/scripts/chicago-crontasks
+++ b/scripts/chicago-crontasks
@@ -1,5 +1,5 @@
 # /etc/cron.d/chicago-crontasks
 APPDIR=/home/datamade/chicago
 PYTHONDIR=/home/datamade/.virtualenvs/chicago/bin/python
-0,15,30,45 * * * * datamade /usr/bin/flock -n /tmp/chicago_dataload.lock -c '$PYTHONDIR manage.py update_index --batch-size=50 --age=1 >> /var/log/councilmatic/chicago-updateindex.log 2>&1'
-0 5 * * * $PYTHONDIR manage.py send_notifications >> /var/log/councilmatic/chicago-sendnotifications.log 2>&1'
+0,15,30,45 * * * * datamade /usr/bin/flock -n /tmp/chicago_dataload.lock -c 'cd $APPDIR && $PYTHONDIR manage.py update_index --batch-size=50 --age=1 >> /var/log/councilmatic/chicago-updateindex.log 2>&1'
+0 5 * * * datamade cd $APPDIR && $PYTHONDIR manage.py send_notifications >> /var/log/councilmatic/chicago-sendnotifications.log 2>&1


### PR DESCRIPTION
## Description

When we launched the Councilmatic upgrade, we broke the production cronjob with invalid syntax. This is the cause of #275: we have the legislation, but our cron to add it to the search index has not been running. This PR fixes the cron.

### Testing instructions

I made this change in place on the server and confirmed it ran:

```
ubuntu@ip-10-0-0-124:~$ grep CRON /var/log/syslog | tail
...
Sep  9 19:45:01 ip-10-0-0-124 CRON[25226]: (datamade) CMD (/usr/bin/flock -n /tmp/chicago_dataload.lock -c 'cd $APPDIR && $PYTHONDIR manage.py update_index --batch-size=50 --age=1 >> /var/log/councilmatic/chicago-updateindex.log 2>&1')
ubuntu@ip-10-0-0-124:~$ tail -f /var/log/councilmatic/chicago-updateindex.log
[14:45:06][INFO] pysolr pysolr.py:_send_request:402 | Finished 'http://127.0.0.1:8983/solr/chicago/update/?commit=true' (post) with body '<add><doc ' in 2.343 seconds, with status 200
Indexing 18 chicago bills
```
Lo and behold!

<img width="1552" alt="Screen Shot 2021-09-09 at 2 54 29 PM" src="https://user-images.githubusercontent.com/12176173/132753709-e902e5b1-f8e3-48ee-b71f-cb515a1edba9.png">

Since we impose an age of 1 (bills updated in the last day) in the cron, which makes perfect sense since update the index 4x an hour, I manually teed off a full reindex in a tmux shell, as we're missing over a year of data.