### PR TITLE
adds roll call to events

### DIFF
--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -4,30 +4,20 @@
 {% block title %}{{event.name}}{% endblock %}
 {% block content %}
 
+  <br/>
+  <p><a href='/events/'><i class="fa fa-angle-double-left" aria-hidden="true"></i> {{ CITY_VOCAB.EVENTS }}</a></p>
+  <h1>{{event.name}}</h1>
+  <p>{{event.description}}</p>
+
+  <p>
+    <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
+    <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
+    <i class="fa fa-fw fa-map-marker"></i> {{event.location}}
+  </p>
+
+  <hr />
   <div class="row-fluid">
-    <div class="col-sm-8">
-      <br/>
-      <p><a href='/events/'><i class="fa fa-angle-double-left" aria-hidden="true"></i> {{ CITY_VOCAB.EVENTS }}</a></p>
-      <h1>{{event.name}}</h1>
-      <p>{{event.description}}</p>
-
-      <p class="text-muted">
-        <i class="fa fa-fw fa-calendar-o"></i> {{event.start_time | date:"D n/d/Y"}}<br/>
-        <i class="fa fa-fw fa-clock-o"></i> {{event.start_time | date:"g:i a"}}<br/>
-        <i class="fa fa-fw fa-map-marker"></i> {{event.location}}
-      </p>
-
-      <hr />
-
-      {% if participants %}
-        <h4>Participants</h4>
-        <p>
-          {% for participant in participants %}
-            <i class="fa fa-fw fa-users"></i> {{participant.link_html | safe}}<br />
-          {% endfor %}
-        </p>
-      {% endif %}
-
+    <div class="col-sm-5">
       {% if event.clean_agenda_items %}
         <h4>Agenda</h4>
         <p>
@@ -58,6 +48,25 @@
         </p>
       {% endif %}
 
+    </div>
+    <div class="col-sm-5">
+      {% if attendance %}
+        <h4>Attendance</h4>
+        <table class="table">
+          <tr>
+            <th>Name</th>
+            <th>Present</th>
+            <th>Absent</th>
+          </tr>
+          {% for p in attendance %}
+            <tr>
+              <td><a href="{% url 'person' p.person.councilmatic_person.slug %}">{{p.person.name}}</a></td>
+              <td>{% if p.attended %}<i class="fa fa-fw fa-check"></i>{%endif%}</td>
+              <td>{% if not p.attended %}<i class="fa fa-fw fa-times"></i>{%endif%}</td>
+            </tr>
+          {% endfor %}
+        </table>
+      {% endif %}
     </div>
   </div>
 

--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -17,7 +17,7 @@
 
   <hr />
   <div class="row-fluid">
-    <div class="col-sm-5">
+    <div class="col-sm-6">
       {% if event.clean_agenda_items %}
         <h4>Agenda</h4>
         <p>
@@ -49,44 +49,33 @@
       {% endif %}
 
     </div>
-    <div class="col-sm-5">
-      {% if attendance %}
-        <h4>Attendance</h4>
-        <div class="row">
-
-        </div>
-
-        {% for p in attendance %}
-          <div class="col-sm-4">
-            <p class="h4">
-              <a href="{% url 'person' p.person.councilmatic_person.slug %}">
-                <span class="label label-{% if p.attended %}active{% else %}failed{% endif %}">
-                  {{p.person.name}}
-                  {% if p.attended %}
-                    <i class="fa fa-fw fa-check"></i>
-                  {% else %}
-                    <i class="fa fa-fw fa-times"></i>
-                  {% endif %}
-                </span>
-              </a>
-            </p>
-          </div>
-        {% endfor %}
-
-        <!-- <table class="table">
+    <div class="col-sm-6">
+      <h4>Attendance</h4>
+      {% if attendance_taken %}
+        <table class="table">
           <tr>
+            <th></th>
             <th>Name</th>
-            <th>Present</th>
-            <th>Absent</th>
+            <th>Ward</th>
+            <th class="text-center">Present</th>
+            <th class="text-center">Absent</th>
           </tr>
           {% for p in attendance %}
             <tr>
-              <td><a href="{% url 'person' p.person.councilmatic_person.slug %}">{{p.person.name}}</a></td>
-              <td>{% if p.attended %}<i class="fa fa-fw fa-check"></i>{%endif%}</td>
-              <td>{% if not p.attended %}<i class="fa fa-fw fa-times"></i>{%endif%}</td>
+              <td>
+                <div class="thumbnail-square">
+                  <img src='{{p.attendee|get_person_headshot}}' alt='{{p.attendee.name}}' title='{{p.attendee.name}}' class='img-responsive img-thumbnail' />
+                </div>
+              </td>
+              <td><a href="{% url 'person' p.attendee.slug %}">{{p.attendee.name}}</a></td>
+              <td>{{ p.attendee.latest_council_seat }}</td>
+              <td class="text-center {% if p.attended %}info{% endif %}">{% if p.attended %}<i class="fa fa-fw fa-check"></i>{%endif%}</td>
+              <td class="text-center {% if not p.attended %}danger{% endif %}">{% if not p.attended %}<i class="fa fa-fw fa-times"></i>{%endif%}</td>
             </tr>
           {% endfor %}
-        </table> -->
+        </table>
+      {% else %}
+        <p>Attendance was not taken for this event.</p>
       {% endif %}
     </div>
   </div>

--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -52,7 +52,28 @@
     <div class="col-sm-5">
       {% if attendance %}
         <h4>Attendance</h4>
-        <table class="table">
+        <div class="row">
+
+        </div>
+
+        {% for p in attendance %}
+          <div class="col-sm-4">
+            <p class="h4">
+              <a href="{% url 'person' p.person.councilmatic_person.slug %}">
+                <span class="label label-{% if p.attended %}active{% else %}failed{% endif %}">
+                  {{p.person.name}}
+                  {% if p.attended %}
+                    <i class="fa fa-fw fa-check"></i>
+                  {% else %}
+                    <i class="fa fa-fw fa-times"></i>
+                  {% endif %}
+                </span>
+              </a>
+            </p>
+          </div>
+        {% endfor %}
+
+        <!-- <table class="table">
           <tr>
             <th>Name</th>
             <th>Present</th>
@@ -65,7 +86,7 @@
               <td>{% if not p.attended %}<i class="fa fa-fw fa-times"></i>{%endif%}</td>
             </tr>
           {% endfor %}
-        </table>
+        </table> -->
       {% endif %}
     </div>
   </div>

--- a/chicago/views.py
+++ b/chicago/views.py
@@ -363,8 +363,14 @@ class ChicagoEventDetailView(EventDetailView):
         attendance = []
         for expected_attendee in sorted(expected_attendees, key=lambda x: x.name):
             attended = expected_attendee.id in attendees
-            attendance.append({"person": expected_attendee, "attended": attended})
+            attendance.append(
+                {
+                    "attendee": expected_attendee.councilmatic_person,
+                    "attended": attended,
+                }
+            )
 
+        context["attendance_taken"] = len(attendees) > 0
         context["attendance"] = attendance
 
         seo = {}

--- a/chicago/views.py
+++ b/chicago/views.py
@@ -358,7 +358,7 @@ class ChicagoEventDetailView(EventDetailView):
 
         attendees = set()
         for event_person in event.participants.filter(entity_type="person"):
-            attendees.add(event_person.person.id)
+            attendees.add(event_person.person_id)
 
         attendance = []
         for expected_attendee in sorted(expected_attendees, key=lambda x: x.name):


### PR DESCRIPTION
Adds alder attendance to events.

I'm deciding between two layouts:

### Table - less compact but has room for more details (ward, picture)
![Screen Shot 2022-12-16 at 4 23 11 PM](https://user-images.githubusercontent.com/919583/208198713-0fb5e016-2642-46d4-a96e-4c00ac7815cb.png)

### Grid list - more compact but at the expense of readability
<img width="1511" alt="Screen Shot 2022-12-18 at 12 42 51 PM" src="https://user-images.githubusercontent.com/919583/208313939-dbc5211e-9c92-4af8-93df-77f8e07d0ba8.png">

Which is better? Also, is it worth it to include Alder headshots on this list?

To do:
 - some events show all participants are absent: http://localhost:8000/event/committee-on-transportation-and-public-0dba80f90653/
 - some events throw an `AttributeError` for missing person ID: http://localhost:8000/event/committee-on-economic-capital-and-9b249e191988/

Closes #301 