### PR TITLE
Attendance updates

### DIFF
--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -78,7 +78,7 @@
           </table>
         {% else %}
           <h4>Attendance</h4>
-          <p>Attendance was not taken for this meeting</p>
+          <p>Attendance was not taken for this meeting or has not been posted by the Clerk's office</p>
         {% endif %}
       {% endif %}
     </div>

--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -43,11 +43,14 @@
         <h4>Attachments</h4>
         <p>
           {% for document in event.documents.all %}
-            <i class='fa fa-fw fa-file-text-o'></i> <a href="{{document.url}}">{{document.note}}</a><br />
+            <i class='fa fa-fw fa-file-text-o'></i> <a href="{{document.links.first.url}}">{{document.note}}</a><br />
           {% endfor %}
         </p>
       {% endif %}
-
+      <div class="modal-links">
+        <!-- View on legistar -->
+        {{ event|get_legistar_link|safe }}
+      </div>
     </div>
     <div class="col-sm-6">
       {% now "Y-m-d" as todays_date %}

--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -51,33 +51,35 @@
     </div>
     <div class="col-sm-6">
       {% now "Y-m-d" as todays_date %}
-      {% if attendance_taken and todays_date > event.start_time|date:"Y-m-d" %}
-        <h4>Attendance: {{attendance_present}} Present, {{attendance_absent}} Absent</h4>
-        <table class="table">
-          <tr>
-            <th></th>
-            <th>Name</th>
-            <th>Ward</th>
-            <th class="text-center">Present</th>
-            <th class="text-center">Absent</th>
-          </tr>
-          {% for p in attendance %}
-            <tr class="{% if not p.attended %}danger{% endif %}">
-              <td>
-                <div class="thumbnail-square">
-                  <img src='{{p.attendee|get_person_headshot}}' alt='{{p.attendee.name}}' title='{{p.attendee.name}}' class='img-responsive img-thumbnail' />
-                </div>
-              </td>
-              <td><a href="{% url 'person' p.attendee.slug %}">{{p.attendee.name}}</a></td>
-              <td>{{ p.attendee.latest_council_seat }}</td>
-              <td class="text-center">{% if p.attended %}<i class="fa fa-fw fa-check"></i>{%endif%}</td>
-              <td class="text-center">{% if not p.attended %}<i class="fa fa-fw fa-times"></i>{%endif%}</td>
+      {% if todays_date > event.start_time|date:"Y-m-d" %}
+        {% if attendance_taken %}
+          <h4>Attendance: {{attendance_present}} Present, {{attendance_absent}} Absent</h4>
+          <table class="table">
+            <tr>
+              <th></th>
+              <th>Name</th>
+              <th>Ward</th>
+              <th class="text-center">Present</th>
+              <th class="text-center">Absent</th>
             </tr>
-          {% endfor %}
-        </table>
-      {% else %}
-        <h4>Attendance</h4>
-        <p>Attendance was not taken for this meeting</p>
+            {% for p in attendance %}
+              <tr class="{% if not p.attended %}danger{% endif %}">
+                <td>
+                  <div class="thumbnail-square">
+                    <img src='{{p.attendee|get_person_headshot}}' alt='{{p.attendee.name}}' title='{{p.attendee.name}}' class='img-responsive img-thumbnail' />
+                  </div>
+                </td>
+                <td><a href="{% url 'person' p.attendee.slug %}">{{p.attendee.name}}</a></td>
+                <td>{{ p.attendee.latest_council_seat }}</td>
+                <td class="text-center">{% if p.attended %}<i class="fa fa-fw fa-check"></i>{%endif%}</td>
+                <td class="text-center">{% if not p.attended %}<i class="fa fa-fw fa-times"></i>{%endif%}</td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% else %}
+          <h4>Attendance</h4>
+          <p>Attendance was not taken for this meeting</p>
+        {% endif %}
       {% endif %}
     </div>
   </div>

--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -1,12 +1,12 @@
 {% extends "base_with_margins.html" %}
 {% load extras chicago_extras %}
 {% load static %}
-{% block title %}{{event.name}}{% endblock %}
+{% block title %}{%if event.status == 'cancelled'%}CANCELLED: {% endif %}{{event.name}}{% endblock %}
 {% block content %}
 
   <br/>
   <p><a href='/events/'><i class="fa fa-angle-double-left" aria-hidden="true"></i> {{ CITY_VOCAB.EVENTS }}</a></p>
-  <h1>{{event.name}}</h1>
+  <h1>{%if event.status == 'cancelled'%}CANCELLED: {% endif %}{{event.name}}</h1>
   <p>{{event.description}}</p>
 
   <p>
@@ -53,8 +53,8 @@
       </div>
     </div>
     <div class="col-sm-6">
-      {% now "Y-m-d" as todays_date %}
-      {% if todays_date > event.start_time|date:"Y-m-d" %}
+      <!-- only show attendance for past events that weren't cancelled -->
+      {% if event.status == 'passed' %}
         {% if attendance_taken %}
           <h4>Attendance: {{attendance_present}} Present, {{attendance_absent}} Absent</h4>
           <table class="table">

--- a/chicago/templates/events.html
+++ b/chicago/templates/events.html
@@ -27,7 +27,7 @@
       </div>
 
       <br />
-      <a href="/events/?form_datetime={{prev_month}}" class="btn btn-sm btn-primary">< Prev month</a>
+      <a href="/events/?form_datetime={{prev_month}}" class="btn btn-sm btn-primary">< Previous month</a>
       <a href="/events/?form_datetime={{next_month}}" class="btn btn-sm btn-primary">Next month ></a>
       {% if select_events %}
         <h2><span>{{ CITY_VOCAB.EVENTS }} in {{select_date}}</span>

--- a/chicago/templates/events.html
+++ b/chicago/templates/events.html
@@ -26,6 +26,9 @@
         </div>
       </div>
 
+      <br />
+      <a href="/events/?form_datetime={{prev_month}}" class="btn btn-sm btn-primary">< Prev month</a>
+      <a href="/events/?form_datetime={{next_month}}" class="btn btn-sm btn-primary">Next month ></a>
       {% if select_events %}
         <h2><span>{{ CITY_VOCAB.EVENTS }} in {{select_date}}</span>
           <br class="non-desktop-only"/>

--- a/chicago/templates/partials/event_time_item.html
+++ b/chicago/templates/partials/event_time_item.html
@@ -6,7 +6,7 @@
   </div>
   <div class="col-xs-9">
     <p>
-      <a href="{{event.event_page_url}}">{{event.name}}</a><br/>
+      <a href="{{event.event_page_url}}">{%if event.status == 'cancelled'%}CANCELLED: {% endif %}{{event.name}}</a><br/>
       <span class="small text-muted">{{event.description}}</span>
     </p>
   </div>

--- a/chicago/templates/partials/event_time_item.html
+++ b/chicago/templates/partials/event_time_item.html
@@ -6,8 +6,12 @@
   </div>
   <div class="col-xs-9">
     <p>
-      <a href="{{event.event_page_url}}">{%if event.status == 'cancelled'%}CANCELLED: {% endif %}{{event.name}}</a><br/>
-      <span class="small text-muted">{{event.description}}</span>
+      {% if event.status == 'cancelled' %}
+        <a href="{{event.event_page_url}}" class="text-muted">CANCELLED: {{event.name}}</a>
+      {% else %}
+        <a href="{{event.event_page_url}}">{{event.name}}</a>
+      {% endif %}
+      <br/><span class="small text-muted">{{event.description}}</span>
     </p>
   </div>
 </div>


### PR DESCRIPTION
* closes #309 
* closes #310 
* restores links to legistar and document links with ocd model updates, related to #299 
* adds previous and next month buttons to events page, brings in events view code from `django-councilmatic`

<img width="1507" alt="Screen Shot 2022-12-23 at 10 20 18 PM" src="https://user-images.githubusercontent.com/919583/209420993-816959f4-6074-4b7b-8be6-7076766531b0.png">
