### PR TITLE
add attendance tab to alder pages

### DIFF
--- a/chicago/templates/person.html
+++ b/chicago/templates/person.html
@@ -94,6 +94,13 @@
           </span>
         </a>
         </li>
+        <li role="presentation" {% if request.GET.view == 'attendance' %}class='active' {% endif %}>    <a href="/person/{{person.slug}}/?view=attendance">
+          <span class="small-pill">
+            <i class='fa fa-fw fa-calendar-o'></i>
+            Attendance
+          </span>
+        </a>
+        </li>
       </ul>
 
       {% if request.GET.view == 'bills' or request.GET.view == None %}
@@ -147,6 +154,35 @@
             </table>
           </div>
         {% endif %}
+      {% endif %}
+
+      {% if request.GET.view == 'attendance' %}
+        <h2>{{person.name}} has {{ attendance_percent }} attendance</h2>
+        <p>Attended {{attendance_present}} events and absent from {{attendance_absent}} events </p>
+
+        <div class="table-responsive">
+          <table class='table'>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Meeting</th>
+                <th class="text-center">Present</th>
+                <th class="text-center">Absent</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for a in attendance %}
+                <tr  class="{% if not a.attended %}danger{% endif %}">
+                  <td>{{a.event.start_time | date:'Y-m-d' }}</td>
+                  <td><a href="{{a.event.event_page_url}}">{{a.event.name}}</a></td>
+                  <td class="text-center">{% if a.attended %}<i class="fa fa-fw fa-check"></i>{%endif%}</td>
+                  <td class="text-center">{% if not a.attended %}<i class="fa fa-fw fa-times"></i>{%endif%}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+
       {% endif %}
 
       <br />

--- a/chicago/templates/person.html
+++ b/chicago/templates/person.html
@@ -158,7 +158,7 @@
 
       {% if request.GET.view == 'attendance' %}
         <h2>{{person.name}} has {{ attendance_percent }} attendance</h2>
-        <p>Attended {{attendance_present}} events and absent from {{attendance_absent}} events </p>
+        <p>Attended {{attendance_present}} events and absent from {{attendance_absent}} events in the current legislative session</p>
 
         <div class="table-responsive">
           <table class='table'>

--- a/chicago/templates/person.html
+++ b/chicago/templates/person.html
@@ -90,14 +90,14 @@
         <li role="presentation" {% if request.GET.view == 'committees' %}class='active' {% endif %}>    <a href="/person/{{person.slug}}/?view=committees">
           <span class="small-pill">
             <i class='fa fa-fw fa-group'></i>
-            Committees
+            Committees ({{committee_count}})
           </span>
         </a>
         </li>
         <li role="presentation" {% if request.GET.view == 'attendance' %}class='active' {% endif %}>    <a href="/person/{{person.slug}}/?view=attendance">
           <span class="small-pill">
             <i class='fa fa-fw fa-calendar-o'></i>
-            Attendance
+            Attendance ({{attendance_percent}})
           </span>
         </a>
         </li>

--- a/chicago/views.py
+++ b/chicago/views.py
@@ -354,16 +354,13 @@ class ChicagoPersonDetailView(PersonDetailView):
             )
 
         for e in sorted(events, key=attrgetter("start_time"), reverse=True):
-            if len(e.attendance) > 0:
-                attended = (
-                    len([p for p in e.attendance if person.id == p.person_id]) > 0
-                )
-                attendance.append(
-                    {
-                        "event": e,
-                        "attended": attended,
-                    }
-                )
+            attended = e.participants.filter(person_id=person.id).exists()
+            attendance.append(
+                {
+                    "event": e,
+                    "attended": attended,
+                }
+            )
 
         context["committee_count"] = len(person.current_memberships) - 1
         context["attendance"] = attendance

--- a/chicago/views.py
+++ b/chicago/views.py
@@ -360,6 +360,7 @@ class ChicagoPersonDetailView(PersonDetailView):
                     }
                 )
 
+        context["committee_count"] = len(person.current_memberships) - 1
         context["attendance"] = attendance
         context["attendance_present"] = len([a for a in attendance if a["attended"]])
         context["attendance_absent"] = len(


### PR DESCRIPTION
Following on from #316 and #308, adds a table to show event attendance for all alderpersons based on their committee memberships.

<img width="1226" alt="Screen Shot 2023-01-01 at 11 08 55 PM" src="https://user-images.githubusercontent.com/919583/210196881-487ddb8e-5f25-4c23-987c-fc2456abf896.png">

A few things to address:
- there may be a more efficient way to make this query. it does seem a bit expensive
- this code doesn't account for committee tenure and is incorrectly marking absences for older events. could use another look to figure out a way to get this in the events query