### PR TITLE
Bill votes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,42 @@ docker-compose up
 
 ### Load in the data
 
-Chicago Councilmatic needs to data work properly.
+Chicago Councilmatic needs to data work properly and the database is quite large (several GB). You can either restore from another database (faster) or scrape the data yourself.
+
+#### Option 1: Import data from production
+
+If you have existing data, bring down your existing data & volumes
+
+```bash
+docker-compose down --volumes
+```
+
+spin up just the postgres container. this will initialize your database
+
+```bash
+docker-compose up postgres
+```
+
+in a new terminal window, shell into the postgres container
+
+```bash
+docker exec -it CONTAINER_ID /bin/bash
+psql -d postgres -U postgres
+```
+
+in the PSQL interpreter, delete the old database
+
+```sql
+DROP DATABASE chi_councilmatic;
+```
+
+then, exit out of PSQL and the container. while the postgres container is still running, run the `heroku pg:pull` command to restore the production data to your local database. This will take about an hour.
+
+```bash
+PGUSER=postgres PGPASSWORD=postgres PGHOST=127.0.0.1 PGPORT=32001 heroku pg:pull DATABASE_URL chi_councilmatic --app chi-councilmatic-production
+```
+
+#### Option 2: Scrape directly from the source
 
 The `docker-compose-scrape.yml` file contains a service to scrape Legistar web API and
 populate your database with standardized data on the council and its members,

--- a/chicago/templates/base.html
+++ b/chicago/templates/base.html
@@ -36,13 +36,13 @@
               <a href="{% url 'about' %}">About</a>
             </li>
             <li>
-              <a href='{% url 'council_members' %}'>{{ CITY_VOCAB.COUNCIL_MEMBERS }}</a>
+              <a href="{% url 'council_members' %}">{{ CITY_VOCAB.COUNCIL_MEMBERS }}</a>
             </li>
             <li>
-              <a href='{% url 'committees' %}'>Committees</a>
+              <a href="{% url 'committees' %}">Committees</a>
             </li>
             <li>
-              <a href='{% url 'events' %}'>{{ CITY_VOCAB.EVENTS }}</a>
+              <a href="{% url 'events' %}">{{ CITY_VOCAB.EVENTS }}</a>
             </li>
             <li>
               <a href="{% url 'search' %}">Legislation</a>

--- a/chicago/templates/legislation.html
+++ b/chicago/templates/legislation.html
@@ -102,9 +102,6 @@
                 <th>Date</th>
                 <th>Legislative body</th>
                 <th>Action</th>
-                <th>Votes for</th>
-                <th>Votes against</th>
-                <th>Other votes</th>
               </tr>
             </thead>
             <tbody>
@@ -114,68 +111,68 @@
                     <span datetime='{{action.date }}'>{{action.date}}</span>
                   </td>
                   <td>
-                    {{action.organization.link_html|safe}}
+                    <a href="{% url 'committee_detail' action.organization.councilmatic_organization.slug %} %}">{{action.organization.name}}</a>
                   </td>
                   <td>
                     <span class='text-{{action.label}}'>{{action.description | remove_action_subj}}</span>
-                    {% if action.related_organization %}
-                      to
-                      {{action.related_organization.link_html|safe}}
-                    {% endif %}
-                  </td>
-                  <td>
+
                     {% if action.vote.counts.all|length > 0 %}
-                      {% for vote in action.vote.counts.all %}
-                        {% if vote.option == 'yes' %}
-                          <strong>{{vote.option|capfirst}}: {{vote.value}}</strong><br />
-                        {% endif %}
-                      {% endfor %}
+                      <table class='table table-responsive'>
+                        <thead>
+                          <tr>
+                            <th>Votes for</th>
+                            <th>Votes against</th>
+                            <th>Other votes</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td>
+                              {% for vote in action.vote.counts.all %}
+                                {% if vote.option == 'yes' %}
+                                  <strong>{{vote.option|capfirst}}: {{vote.value}}</strong><br />
+                                {% endif %}
+                              {% endfor %}
+                              <p class="small nowrap">
+                                {% for personvote in action.vote.votes.all|dictsort:"voter_name" %}
+                                  {% if personvote.option == 'yes' %}
+                                    <i class="fa fa-fw fa-check"></i> <a href="{% url 'person' personvote.voter.councilmatic_person.slug %}">{{personvote.voter.name}}</a><br />
+                                  {% endif %}
+                                {% endfor %}
+                              </p>
+                            </td>
+                            <td>
+                              {% for vote in action.vote.counts.all %}
+                                {% if vote.option == 'no' %}
+                                  <strong>{{vote.option|capfirst}}: {{vote.value}}</strong><br />
+                                {% endif %}
+                              {% endfor %}
+                              <p class="small nowrap">
+                                {% for personvote in action.vote.votes.all|dictsort:"voter_name" %}
+                                  {% if personvote.option == 'no' %}
+                                    <i class="fa fa-fw fa-times"></i> <a href="{% url 'person' personvote.voter.councilmatic_person.slug %}">{{personvote.voter.name}}</a><br />
+                                  {% endif %}
+                                {% endfor %}
+                              </p>
+                            </td>
+                            <td>
+                              {% for vote in action.vote.counts.all %}
+                                {% if vote.option != 'yes' and vote.option != 'no' %}
+                                  <strong>{{vote.option|capfirst}}: {{vote.value}}</strong><br />
+                                {% endif %}
+                              {% endfor %}
+                              <p class="small nowrap">
+                                {% for personvote in action.vote.votes.all|dictsort:"voter_name" %}
+                                  {% if personvote.option != 'yes' and personvote.option != 'no' %}
+                                    {{ personvote.option|capfirst}}: <a href="{% url 'person' personvote.voter.councilmatic_person.slug %}">{{personvote.voter.name}}</a><br />
+                                  {% endif %}
+                                {% endfor %}
+                              </p>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
                     {% endif %}
-                    <p class="small nowrap">
-                      {% if action.vote.votes.all|length > 0 %}
-                        {% for personvote in action.vote.votes.all|dictsort:"voter_name" %}
-                          {% if personvote.option == 'yes' %}
-                            <i class="fa fa-fw fa-check"></i> <a href="{% url 'person' personvote.voter.councilmatic_person.slug %}">{{personvote.voter.name}}</a><br />
-                          {% endif %}
-                        {% endfor %}
-                      {% endif %}
-                    </p>
-                  </td>
-                  <td>
-                    {% if action.vote.counts.all|length > 0 %}
-                      {% for vote in action.vote.counts.all %}
-                        {% if vote.option == 'no' %}
-                          <strong>{{vote.option|capfirst}}: {{vote.value}}</strong><br />
-                        {% endif %}
-                      {% endfor %}
-                    {% endif %}
-                    <p class="small nowrap">
-                      {% if action.vote.votes.all|length > 0 %}
-                        {% for personvote in action.vote.votes.all|dictsort:"voter_name" %}
-                          {% if personvote.option == 'no' %}
-                            <i class="fa fa-fw fa-times"></i> <a href="{% url 'person' personvote.voter.councilmatic_person.slug %}">{{personvote.voter.name}}</a><br />
-                          {% endif %}
-                        {% endfor %}
-                      {% endif %}
-                    </p>
-                  </td>
-                  <td>
-                    {% if action.vote.counts.all|length > 0 %}
-                      {% for vote in action.vote.counts.all %}
-                        {% if vote.option != 'yes' and vote.option != 'no' %}
-                          <strong>{{vote.option|capfirst}}: {{vote.value}}</strong><br />
-                        {% endif %}
-                      {% endfor %}
-                    {% endif %}
-                    <p class="small nowrap">
-                      {% if action.vote.votes.all|length > 0 %}
-                        {% for personvote in action.vote.votes.all|dictsort:"voter_name" %}
-                          {% if personvote.option != 'yes' and personvote.option != 'no' %}
-                            {{ personvote.option|capfirst}}: <a href="{% url 'person' personvote.voter.councilmatic_person.slug %}">{{personvote.voter.name}}</a><br />
-                          {% endif %}
-                        {% endfor %}
-                      {% endif %}
-                    </p>
                   </td>
                 </tr>
               {% endfor %}

--- a/chicago/templates/legislation.html
+++ b/chicago/templates/legislation.html
@@ -100,25 +100,82 @@
             <thead>
               <tr>
                 <th>Date</th>
-                <th>Action</th>
                 <th>Legislative body</th>
+                <th>Action</th>
+                <th>Votes for</th>
+                <th>Votes against</th>
+                <th>Other votes</th>
               </tr>
             </thead>
             <tbody>
               {% for action in actions %}
                 <tr>
-                  <td class='nowrap text-muted small'>
+                  <td class='nowrap text-muted'>
                     <span datetime='{{action.date }}'>{{action.date}}</span>
                   </td>
-                  <td class="small">
+                  <td>
+                    {{action.organization.link_html|safe}}
+                  </td>
+                  <td>
                     <span class='text-{{action.label}}'>{{action.description | remove_action_subj}}</span>
                     {% if action.related_organization %}
                       to
                       {{action.related_organization.link_html|safe}}
                     {% endif %}
                   </td>
-                  <td class="small">
-                    {{action.organization.link_html|safe}}
+                  <td>
+                    {% if action.vote.counts.all|length > 0 %}
+                      {% for vote in action.vote.counts.all %}
+                        {% if vote.option == 'yes' %}
+                          <strong>{{vote.option|capfirst}}: {{vote.value}}</strong><br />
+                        {% endif %}
+                      {% endfor %}
+                    {% endif %}
+                    <p class="small nowrap">
+                      {% if action.vote.votes.all|length > 0 %}
+                        {% for personvote in action.vote.votes.all|dictsort:"voter_name" %}
+                          {% if personvote.option == 'yes' %}
+                            <i class="fa fa-fw fa-check"></i> <a href="{% url 'person' personvote.voter.councilmatic_person.slug %}">{{personvote.voter.name}}</a><br />
+                          {% endif %}
+                        {% endfor %}
+                      {% endif %}
+                    </p>
+                  </td>
+                  <td>
+                    {% if action.vote.counts.all|length > 0 %}
+                      {% for vote in action.vote.counts.all %}
+                        {% if vote.option == 'no' %}
+                          <strong>{{vote.option|capfirst}}: {{vote.value}}</strong><br />
+                        {% endif %}
+                      {% endfor %}
+                    {% endif %}
+                    <p class="small nowrap">
+                      {% if action.vote.votes.all|length > 0 %}
+                        {% for personvote in action.vote.votes.all|dictsort:"voter_name" %}
+                          {% if personvote.option == 'no' %}
+                            <i class="fa fa-fw fa-times"></i> <a href="{% url 'person' personvote.voter.councilmatic_person.slug %}">{{personvote.voter.name}}</a><br />
+                          {% endif %}
+                        {% endfor %}
+                      {% endif %}
+                    </p>
+                  </td>
+                  <td>
+                    {% if action.vote.counts.all|length > 0 %}
+                      {% for vote in action.vote.counts.all %}
+                        {% if vote.option != 'yes' and vote.option != 'no' %}
+                          <strong>{{vote.option|capfirst}}: {{vote.value}}</strong><br />
+                        {% endif %}
+                      {% endfor %}
+                    {% endif %}
+                    <p class="small nowrap">
+                      {% if action.vote.votes.all|length > 0 %}
+                        {% for personvote in action.vote.votes.all|dictsort:"voter_name" %}
+                          {% if personvote.option != 'yes' and personvote.option != 'no' %}
+                            {{ personvote.option|capfirst}}: <a href="{% url 'person' personvote.voter.councilmatic_person.slug %}">{{personvote.voter.name}}</a><br />
+                          {% endif %}
+                        {% endfor %}
+                      {% endif %}
+                    </p>
                   </td>
                 </tr>
               {% endfor %}

--- a/chicago/views.py
+++ b/chicago/views.py
@@ -27,7 +27,7 @@ from councilmatic_core.views import (
     CommitteeDetailView,
     CouncilmaticSearchForm,
 )
-from councilmatic_core.models import Post
+from councilmatic_core.models import Post, Organization
 from opencivicdata.legislative.models import LegislativeSession
 
 from haystack.generic_views import FacetedSearchView
@@ -376,6 +376,9 @@ class ChicagoPersonDetailView(PersonDetailView):
 
 class ChicagoCommitteesView(CommitteesView):
     template_name = "committees.html"
+
+    def get_queryset(self):
+        return Organization.committees().distinct("name")
 
 
 class ChicagoCommitteeDetailView(CommitteeDetailView):


### PR DESCRIPTION
Was able to pull the latest data from production and update the README instructions for others with access to reproduce.

This PR is a first pass at representing votes for actions related to bills. It shows a total along with the list of voters with links to their profiles. Totals are grouped by "Votes for", "Votes against" and "Other votes" which include "Absent", "Not voting" and everything else.

Here's a few examples:

Ordinance O2017-2027: Amendment of Municipal Code Title 2 by removing individuals retained as independent contractors from definition of "City employee" and "City Council employee" (failed)
![Screen Shot 2023-01-03 at 4 32 25 PM](https://user-images.githubusercontent.com/919583/210452762-527c896a-ce51-475b-b1ec-e164fc47adbc.png)

Routine committee vote on Ordinance O2011-3749 with a committee vote and a full council vote

![Screen Shot 2023-01-03 at 4 39 03 PM](https://user-images.githubusercontent.com/919583/210453098-f95ba279-32f2-4c43-8dbb-fb80974f9878.png)

![Screen Shot 2023-01-03 at 4 32 13 PM](https://user-images.githubusercontent.com/919583/210452937-2ddf8767-6a84-4416-9f7f-36aa1f8b6eb2.png)

There are a lot of votes that are 45+ votes in favor, which makes the list quite long. Thinking of truncating to the top 20 and adding a 'show more' button in this case


Closes #300
Closes #305 

This is branched off of `alder-attendance` so we should bring in #317 first