### PR TITLE
handle term dates for former alds

### DIFF
--- a/chicago/models.py
+++ b/chicago/models.py
@@ -252,10 +252,21 @@ class ChicagoPerson(Person):
         return ""
 
     @property
+    def term_active(self):
+        return self.latest_council_membership.end_date_dt > timezone.now()
+
+    @property
     def years_in_office(self):
-        years = relativedelta(
-            timezone.now(), self.latest_council_membership.start_date_dt
-        ).years
+        years = 0
+        if self.term_active:
+            years = relativedelta(
+                timezone.now(), self.latest_council_membership.start_date_dt
+            ).years
+        else:
+            years = relativedelta(
+                self.latest_council_membership.end_date_dt,
+                self.latest_council_membership.start_date_dt,
+            ).years
 
         if years == 0:
             return "< 1"

--- a/chicago/templates/person.html
+++ b/chicago/templates/person.html
@@ -15,7 +15,7 @@
     <div class="col-sm-10">
       <h1>
         {{person.name}}
-        <small>{{ person.latest_council_membership.post.label }} {{ person.latest_council_membership.role }}</small>
+        <small>{% if not person.term_active %}Former {% endif %}{{ person.latest_council_membership.post.label }} {{ person.latest_council_membership.role }}</small>
       </h1>
     </div>
   </div>
@@ -24,19 +24,24 @@
     <div class="col-sm-3">
       <img src='{{ person|get_person_headshot }}' alt='{{person.name}}' title='{{person.name}}' class='img-responsive img-padded' id="person-detail-headshot" />
 
-      {% if tenure_start %}
-        <br>
-        <p>In office since <strong>{{ tenure_start }}</strong> ({{ person.years_in_office }} years)</p>
-      {% endif %}
-
-      <p>
-        <strong>2023 election status</strong><br />
-        {% if person.election_status %}
-          {{ person.election_status }}
-        {% else %}
-          Running for re-election
+      {% if person.term_active %}
+        {% if tenure_start %}
+          <br>
+          <p>In office since <strong>{{ tenure_start }}</strong> ({{ person.years_in_office }} years)</p>
         {% endif %}
-      </p>
+
+        <p>
+          <strong>2023 election status</strong><br />
+          {% if person.election_status %}
+            {{ person.election_status }}
+          {% else %}
+            Running for re-election
+          {% endif %}
+        </p>
+      {% else %}
+        <br>
+        <p>In office from <strong>{{ tenure_start }}</strong> to <strong>{{ tenure_end }}</strong> ({{ person.years_in_office }} years)</p>
+      {% endif %}
 
       {% if person.caucus %}
         <p><strong>Caucuses with</strong><br />{{ person.caucus }}</p>
@@ -110,7 +115,7 @@
         <li role="presentation" {% if request.GET.view == 'attendance' %}class='active' {% endif %}>    <a href="/person/{{person.slug}}/?view=attendance">
           <span class="small-pill">
             <i class='fa fa-fw fa-calendar-o'></i>
-            Attendance ({{attendance_percent}})
+            Attendance ({{person.attendance_percent}})
           </span>
         </a>
         </li>

--- a/chicago/views.py
+++ b/chicago/views.py
@@ -323,6 +323,9 @@ class ChicagoPersonDetailView(PersonDetailView):
             context[
                 "tenure_start"
             ] = person.latest_council_membership.start_date_dt.strftime("%B %d, %Y")
+            context[
+                "tenure_end"
+            ] = person.latest_council_membership.end_date_dt.strftime("%B %d, %Y")
 
         context["chair_positions"] = person.chair_role_memberships
 
@@ -340,9 +343,6 @@ class ChicagoPersonDetailView(PersonDetailView):
         context["attendance_present"] = len([a for a in attendance if a["attended"]])
         context["attendance_absent"] = len(
             [a for a in attendance if a["attended"] is False]
-        )
-        context["attendance_percent"] = "{:.0%}".format(
-            context["attendance_present"] / (len(attendance))
         )
         return context
 


### PR DESCRIPTION
Resolves https://sentry.io/organizations/datamade/issues/3858894029/?project=63977 by using `ChicagoPerson.attendance_percent` in template

Also adds some template logic to handle display of term dates and titles for former Aldermen.