### PR TITLE
Simplify cache

### DIFF
--- a/chicago/templates/about.html
+++ b/chicago/templates/about.html
@@ -1,163 +1,159 @@
 {% extends "base_with_margins.html" %}
-{% load adv_cache %}
 {% block title %}About{% endblock %}
 {% block content %}
 
-  {% cache 86400 about_wrapper 'about' %}
+  <div class="row-fluid clearfix">
+    <div class="col-sm-8 ">
+      <br />
+      <h1 id='about'>About</h1>
 
-    <div class="row-fluid clearfix">
-      <div class="col-sm-8 ">
-        <br />
-        <h1 id='about'>About</h1>
+      <p><strong>Chicago Councilmatic</strong> tracks all things related to Chicago City Council: the <a href='/search/'>legislation</a> introduced and passed, its various <a href='/committees/'>committees</a> and the <a href='/events/'>meetings</a> they hold, and the <a href='/council-members/'>aldermen</a> themselves.</p>
 
-        <p><strong>Chicago Councilmatic</strong> tracks all things related to Chicago City Council: the <a href='/search/'>legislation</a> introduced and passed, its various <a href='/committees/'>committees</a> and the <a href='/events/'>meetings</a> they hold, and the <a href='/council-members/'>aldermen</a> themselves.</p>
-
-        <p>You can search and browse legislation from 2011 onwards. Some interesting searches include:</p>
-
-        <ul>
-          <li><a href="/search/?q=&selected_facets=topics_exact:Zoning Reclassification" >changes in how properties are zoned</a></li>
-          <li><a href="/search/?q=settlement&selected_facets=bill_type_exact:Report" >what the City is paying out in settlements</a></li>
-          <li><a href="/search/?q=&selected_facets=topics_exact:Committe Appointments" >committee appointments</a></li>
-          <li><a href="/search/?q=birthday" >celebrating birthdays?!</a></li>
-        </ul>
-
-        <p>Chicago Councilmatic is a free and easy way to access official Chicago City Council information.</p>
-
-      </div>
-      <div class="col-sm-4 desktop-only">
-        <div class="well well-sm">
-          <h4>Contents</h4>
-          <ul class="less-pad-list">
-            <li>
-              <a href="/about">About</a>
-            </li>
-            <li>
-              <a href="#about-city-council">What is Chicago City Council,<br />and how does it work?</a>
-            </li>
-            <li>
-              <a href="#tags">Legislation tags</a>
-            </li>
-            <li>
-              <a href="#open-source">We're open source!</a>
-            </li>
-            <li>
-              <a href="#data">Data</a>
-            </li>
-            <li>
-              <a href="#team">Team</a>
-            </li>
-            <li>
-              <a href="#contact">Contact us</a>
-            </li>
-            <li>
-              <a href="#bring-councilmatic">Bring Councilmatic to your city!</a>
-            </li>
-            <li>
-              <a href="#credits">Credits</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-    <div class="row-fluid">
-      <div class="col-sm-8" id="about-city-council">
-        <h3>What is Chicago City Council, and how does it work?</h3>
-
-        <p>Chicago City Council is the legislative body of the City of Chicago. It consists of <a href='/council-members' >50 elected aldermen</a>, each representing one of Chicago's wards. City Council meets monthly and is presided over by <a href='/person/lightfoot-lori-e-f6faf37c9643/' >Lori Lightfoot</a>, the Mayor of Chicago. The secretary is <a href='/person/valencia-anna-m-ae119fe8c2e3/' >Anna Valencia</a>, City Clerk of Chicago</a>.</p>
-
-      <p>Generally, Chicago City Council deals with the following topics:</p>
+      <p>You can search and browse legislation from 2011 onwards. Some interesting searches include:</p>
 
       <ul>
-        <li><a href='/search/?&selected_facets=topics_exact:City%20Matters' >city-wide policies</a> - usually proposed by the mayor</li>
-        <li><a href='/search/?&selected_facets=topics_exact:Ward%20Matters' >local ward matters</a> - spearheaded by Aldermen</li>
-        <li><a href='/search/?&selected_facets=topics_exact:Residents' >matters involving individuals</a> - miscellaneous claims & honorifics</li>
+        <li><a href="/search/?q=&selected_facets=topics_exact:Zoning Reclassification" >changes in how properties are zoned</a></li>
+        <li><a href="/search/?q=settlement&selected_facets=bill_type_exact:Report" >what the City is paying out in settlements</a></li>
+        <li><a href="/search/?q=&selected_facets=topics_exact:Committe Appointments" >committee appointments</a></li>
+        <li><a href="/search/?q=birthday" >celebrating birthdays?!</a></li>
       </ul>
 
-      <p>For the nitty-gritty on how Chicago City Council works, read about its <a href='http://chicityclerk.com/city-council-news-central/council-agenda' target="_blank">structure</a> and <a href='http://www.chicityclerk.com/city-council-news-central/rules-order' target="_blank">rules</a> from the City Clerk.</p>
-
-      <br/>
-      <h4>Types of legislation</h4>
-      <p>Below are the categories of legislation in Chicago:</p>
-
-      {% include 'partials/component_bill_type_table.html' %}
+      <p>Chicago Councilmatic is a free and easy way to access official Chicago City Council information.</p>
 
     </div>
-    </div>
-
-
-    <div class="row-fluid">
-      <div class="col-sm-8" id="tags">
-        <h3 id='tags'>Legislation tags</h3>
-        <p>One of the more unusual aspects of Chicago City Council is the volume of ordinances that are introduced and passed every month. Most of these are routine items like <a href='/search/?q=&selected_facets=topics_exact:Sign%20permits' >sign permits</a>, <a href='/search/?q=&selected_facets=topics_exact:Damage to vehicle claim' >damaged vehicle claims</a>, <a href='/search/?q=&selected_facets=topics_exact:Sidewalk cafe' >sidewalk cafe approvals</a> and <a href='/search/?q=&selected_facets=topics_exact:Honorifics' >honorifics</a>. </p>
-
-        <p>To help sort through all of this, we classify all legislation and tag it appropriately. If something doesn’t look like a routine piece of legislation, we tag it as <a href='/search/?q=&selected_facets=topics_exact:Non-Routine' >Non-Routine</a> to make it easier to discover.</p>
-
+    <div class="col-sm-4 desktop-only">
+      <div class="well well-sm">
+        <h4>Contents</h4>
+        <ul class="less-pad-list">
+          <li>
+            <a href="/about">About</a>
+          </li>
+          <li>
+            <a href="#about-city-council">What is Chicago City Council,<br />and how does it work?</a>
+          </li>
+          <li>
+            <a href="#tags">Legislation tags</a>
+          </li>
+          <li>
+            <a href="#open-source">We're open source!</a>
+          </li>
+          <li>
+            <a href="#data">Data</a>
+          </li>
+          <li>
+            <a href="#team">Team</a>
+          </li>
+          <li>
+            <a href="#contact">Contact us</a>
+          </li>
+          <li>
+            <a href="#bring-councilmatic">Bring Councilmatic to your city!</a>
+          </li>
+          <li>
+            <a href="#credits">Credits</a>
+          </li>
+        </ul>
       </div>
     </div>
-    <div class="row-fluid">
-      <div class="col-sm-8" id="open-source">
-        <h3>We're open source!</h3>
-        <p>
-          This website is open source and on <a href="https://github.com/datamade/chi-councilmatic" target="_blank">GitHub</a> - meaning that anyone can re-use or adapt the code.
-        </p>
-      </div>
+  </div>
+  <div class="row-fluid">
+    <div class="col-sm-8" id="about-city-council">
+      <h3>What is Chicago City Council, and how does it work?</h3>
+
+      <p>Chicago City Council is the legislative body of the City of Chicago. It consists of <a href='/council-members' >50 elected aldermen</a>, each representing one of Chicago's wards. City Council meets monthly and is presided over by <a href='/person/lightfoot-lori-e-f6faf37c9643/' >Lori Lightfoot</a>, the Mayor of Chicago. The secretary is <a href='/person/valencia-anna-m-ae119fe8c2e3/' >Anna Valencia</a>, City Clerk of Chicago</a>.</p>
+
+    <p>Generally, Chicago City Council deals with the following topics:</p>
+
+    <ul>
+      <li><a href='/search/?&selected_facets=topics_exact:City%20Matters' >city-wide policies</a> - usually proposed by the mayor</li>
+      <li><a href='/search/?&selected_facets=topics_exact:Ward%20Matters' >local ward matters</a> - spearheaded by Aldermen</li>
+      <li><a href='/search/?&selected_facets=topics_exact:Residents' >matters involving individuals</a> - miscellaneous claims & honorifics</li>
+    </ul>
+
+    <p>For the nitty-gritty on how Chicago City Council works, read about its <a href='http://chicityclerk.com/city-council-news-central/council-agenda' target="_blank">structure</a> and <a href='http://www.chicityclerk.com/city-council-news-central/rules-order' target="_blank">rules</a> from the City Clerk.</p>
+
+    <br/>
+    <h4>Types of legislation</h4>
+    <p>Below are the categories of legislation in Chicago:</p>
+
+    {% include 'partials/component_bill_type_table.html' %}
+
+  </div>
+  </div>
+
+
+  <div class="row-fluid">
+    <div class="col-sm-8" id="tags">
+      <h3 id='tags'>Legislation tags</h3>
+      <p>One of the more unusual aspects of Chicago City Council is the volume of ordinances that are introduced and passed every month. Most of these are routine items like <a href='/search/?q=&selected_facets=topics_exact:Sign%20permits' >sign permits</a>, <a href='/search/?q=&selected_facets=topics_exact:Damage to vehicle claim' >damaged vehicle claims</a>, <a href='/search/?q=&selected_facets=topics_exact:Sidewalk cafe' >sidewalk cafe approvals</a> and <a href='/search/?q=&selected_facets=topics_exact:Honorifics' >honorifics</a>. </p>
+
+      <p>To help sort through all of this, we classify all legislation and tag it appropriately. If something doesn’t look like a routine piece of legislation, we tag it as <a href='/search/?q=&selected_facets=topics_exact:Non-Routine' >Non-Routine</a> to make it easier to discover.</p>
+
     </div>
-    <div class="row-fluid">
-      <div class="col-sm-8" id="data">
-        <h3>Data</h3>
-
-        <p>The data on this website comes from the <a href="http://chicago.legistar.com/" target="_blank">Chicago City Council legislation site</a>, a system built by <a href='http://www.granicus.com/' target="_blank">Granicus</a> using their <a href='https://www.granicus.com/solutions/meeting-agenda-suite/' target="_blank">Legistar Legislative Management Suite</a>. The <a href='http://chicityclerk.com/' target="_blank">Office of the City Clerk</a>manages the data, and on Councilmatic, each piece of legislation provides a link to its source for reference.</p>
-
-        <p>Daily, DataMade collects data from Legistar and the <a href='http://webapi.legistar.com/' target="_blank">Legistar Web API</a>, which we store using the <a href="https://github.com/opencivicdata" target="_blank">Open Civic Data</a> standard and platform. Built in collaboration with <a href="http://sunlightfoundation.com/" target="_blank">The Sunlight Foundation</a>, <a href="https://developers.google.com/civic-information/?hl=en" target="_blank">Google</a>, <a href="http://www.granicus.com/" target="_blank">Granicus</a>, and <a href="http://www.opennorth.ca/" target="_blank">Open North</a>, Open Civic Data standardizes information about people, organizations, events, and bills at any level of government.</p>
-
-        <p><a href='http://opencivicdata.org' target="_blank"><img style='height:100px;' src='/static/images/ocd.jpg' /></a></p>
-
-        <br>
-        <a class='btn btn-primary' href='http://ocd-api-documentation.readthedocs.io/en/latest/index.html' target='_blank'>Read OCD API documentation<i class="fa fa-chevron-right" aria-hidden="true"></i></a>
-        <br>
-      </div>
-
+  </div>
+  <div class="row-fluid">
+    <div class="col-sm-8" id="open-source">
+      <h3>We're open source!</h3>
+      <p>
+        This website is open source and on <a href="https://github.com/datamade/chi-councilmatic" target="_blank">GitHub</a> - meaning that anyone can re-use or adapt the code.
+      </p>
     </div>
-    </div>
-    <div class="row-fluid">
-      <div class="col-sm-8" id="team">
-        <h3>Team</h3>
+  </div>
+  <div class="row-fluid">
+    <div class="col-sm-8" id="data">
+      <h3>Data</h3>
 
-        <p><a href='https://datamade.us' target="_blank"><img style='height:50px;' src='/static/images/datamade-logo.png' /></a></p>
+      <p>The data on this website comes from the <a href="http://chicago.legistar.com/" target="_blank">Chicago City Council legislation site</a>, a system built by <a href='http://www.granicus.com/' target="_blank">Granicus</a> using their <a href='https://www.granicus.com/solutions/meeting-agenda-suite/' target="_blank">Legistar Legislative Management Suite</a>. The <a href='http://chicityclerk.com/' target="_blank">Office of the City Clerk</a>manages the data, and on Councilmatic, each piece of legislation provides a link to its source for reference.</p>
 
-        <p>The site was built by <a href='https://datamade.us' target="_blank">DataMade</a>, a civic technology company. They build open source technology using open data to empower journalists, researchers, governments and advocacy organizations.</p>
-      </div>
+      <p>Daily, DataMade collects data from Legistar and the <a href='http://webapi.legistar.com/' target="_blank">Legistar Web API</a>, which we store using the <a href="https://github.com/opencivicdata" target="_blank">Open Civic Data</a> standard and platform. Built in collaboration with <a href="http://sunlightfoundation.com/" target="_blank">The Sunlight Foundation</a>, <a href="https://developers.google.com/civic-information/?hl=en" target="_blank">Google</a>, <a href="http://www.granicus.com/" target="_blank">Granicus</a>, and <a href="http://www.opennorth.ca/" target="_blank">Open North</a>, Open Civic Data standardizes information about people, organizations, events, and bills at any level of government.</p>
+
+      <p><a href='http://opencivicdata.org' target="_blank"><img style='height:100px;' src='/static/images/ocd.jpg' /></a></p>
+
+      <br>
+      <a class='btn btn-primary' href='http://ocd-api-documentation.readthedocs.io/en/latest/index.html' target='_blank'>Read OCD API documentation<i class="fa fa-chevron-right" aria-hidden="true"></i></a>
+      <br>
     </div>
 
-    <div class="row-fluid">
-      <div class="col-sm-8" id="contact">
-        <h3>Contact us</h3>
+  </div>
+  </div>
+  <div class="row-fluid">
+    <div class="col-sm-8" id="team">
+      <h3>Team</h3>
 
-        <p>Have a question about information you were seeking to find, or explanations of how Chicago City Council works? Send us an email <a href='mailto:info@datamade.us'>info@datamade.us</a>.</p>
+      <p><a href='https://datamade.us' target="_blank"><img style='height:50px;' src='/static/images/datamade-logo.png' /></a></p>
 
-        <p>Developers: if you notice a bug, file an issue on our <a href='https://github.com/datamade/chi-councilmatic/' target="_blank">issue tracker</a>!</p>
-
-
-      </div>
+      <p>The site was built by <a href='https://datamade.us' target="_blank">DataMade</a>, a civic technology company. They build open source technology using open data to empower journalists, researchers, governments and advocacy organizations.</p>
     </div>
+  </div>
 
-    <div class="row-fluid">
-      <div class="col-sm-8" id="credits">
-        <h3>Credits</h3>
-        <p><strong>Councilmatic</strong> was originally created by <a href='https://twitter.com/mjumbewu' target="_blank">Mjumbe Poe</a> for <a href='http://philly.councilmatic.org' target="_blank">Philadelphia</a>, during his time as a 2011 <a href='http://www.codeforamerica.org/' target="_blank">Code For America</a> Fellow. It was the first fully-developed open data site for municipal legislation in the United States.</p>
+  <div class="row-fluid">
+    <div class="col-sm-8" id="contact">
+      <h3>Contact us</h3>
 
-        <p><strong>Chicago Councilmatic</strong> was <a href='https://derekeder.com/blog/keeping-tabs-on-your-local-city-council-with-councilmatic' target="_blank">first rolled out in June 2013</a> by Derek Eder and Forest Gregg under <a href='http://opencityapps.org' target="_blank">Open City</a>.</p>
+      <p>Have a question about information you were seeking to find, or explanations of how Chicago City Council works? Send us an email <a href='mailto:info@datamade.us'>info@datamade.us</a>.</p>
 
-        <h4>Photo credits</h4>
+      <p>Developers: if you notice a bug, file an issue on our <a href='https://github.com/datamade/chi-councilmatic/' target="_blank">issue tracker</a>!</p>
 
-        <ul class="small plain-list text-muted">
-          <li>Chicago City Hall: Chicago Ideas</li>
-          <li>Chicago City Council Chambers: Daniel X. O'Neil</li>
-          <li>User Icon: Richard Schumann<li>
-          </ul>
 
-          </div>
+    </div>
+  </div>
+
+  <div class="row-fluid">
+    <div class="col-sm-8" id="credits">
+      <h3>Credits</h3>
+      <p><strong>Councilmatic</strong> was originally created by <a href='https://twitter.com/mjumbewu' target="_blank">Mjumbe Poe</a> for <a href='http://philly.councilmatic.org' target="_blank">Philadelphia</a>, during his time as a 2011 <a href='http://www.codeforamerica.org/' target="_blank">Code For America</a> Fellow. It was the first fully-developed open data site for municipal legislation in the United States.</p>
+
+      <p><strong>Chicago Councilmatic</strong> was <a href='https://derekeder.com/blog/keeping-tabs-on-your-local-city-council-with-councilmatic' target="_blank">first rolled out in June 2013</a> by Derek Eder and Forest Gregg under <a href='http://opencityapps.org' target="_blank">Open City</a>.</p>
+
+      <h4>Photo credits</h4>
+
+      <ul class="small plain-list text-muted">
+        <li>Chicago City Hall: Chicago Ideas</li>
+        <li>Chicago City Council Chambers: Daniel X. O'Neil</li>
+        <li>User Icon: Richard Schumann<li>
+        </ul>
+
         </div>
+      </div>
 
-  {% endcache %}
 {% endblock %}

--- a/chicago/templates/base.html
+++ b/chicago/templates/base.html
@@ -1,5 +1,4 @@
 {% load static %}
-{% load adv_cache %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -21,60 +20,55 @@
 
   </head>
   <body>
-    {% cache 600 nav_wrapper 'nav' %}
 
-      <nav class="navbar navbar-default navbar-fixed-top">
-        <div class="container-fluid container-fluid-nav">
-          <div id="nav-title">
-            <a class="navbar-brand" href="/">
-              <img id="logo" src="{% static 'images/logo.png' %}"></img>
-              <span id="logo-text">{{ CITY_NAME_SHORT }} Councilmatic</span>
-            </a>
-          </div>
-          <ul id="nav-items">
-            <li>
-              <a href="{% url 'about' %}">About</a>
-            </li>
-            <li>
-              <a href="{% url 'council_members' %}">{{ CITY_VOCAB.COUNCIL_MEMBERS }}</a>
-            </li>
-            <li>
-              <a href="/compare-council-members">Compare Aldermen</a>
-            </li>
-            <li>
-              <a href="/divided-votes">Divided Votes</a>
-            </li>
-            <li>
-              <a href="{% url 'committees' %}">Committees</a>
-            </li>
-            <li>
-              <a href="{% url 'events' %}">{{ CITY_VOCAB.EVENTS }}</a>
-            </li>
-            <li>
-              <a href="{% url 'search' %}">Legislation</a>
-            </li>
-          </ul>
+    <nav class="navbar navbar-default navbar-fixed-top">
+      <div class="container-fluid container-fluid-nav">
+        <div id="nav-title">
+          <a class="navbar-brand" href="/">
+            <img id="logo" src="{% static 'images/logo.png' %}"></img>
+            <span id="logo-text">{{ CITY_NAME_SHORT }} Councilmatic</span>
+          </a>
         </div>
-      </nav>
+        <ul id="nav-items">
+          <li>
+            <a href="{% url 'about' %}">About</a>
+          </li>
+          <li>
+            <a href="{% url 'council_members' %}">{{ CITY_VOCAB.COUNCIL_MEMBERS }}</a>
+          </li>
+          <li>
+            <a href="/compare-council-members">Compare Aldermen</a>
+          </li>
+          <li>
+            <a href="/divided-votes">Divided Votes</a>
+          </li>
+          <li>
+            <a href="{% url 'committees' %}">Committees</a>
+          </li>
+          <li>
+            <a href="{% url 'events' %}">{{ CITY_VOCAB.EVENTS }}</a>
+          </li>
+          <li>
+            <a href="{% url 'search' %}">Legislation</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
 
-      <br>
-      {% nocache %}
-        {% if messages %}
-          <div class="container">
-            <div class="row">
-              <div class="col-sm-12">
-                {% for message in messages %}
-                  <div {% if message.tags %}class="alert-signup alert alert-info {{ message.tags }}"{% endif %} role="alert">
-                    {{ message }}
-                  </div>
-                {% endfor %}
+    <br>
+    {% if messages %}
+      <div class="container">
+        <div class="row">
+          <div class="col-sm-12">
+            {% for message in messages %}
+              <div {% if message.tags %}class="alert-signup alert alert-info {{ message.tags }}"{% endif %} role="alert">
+                {{ message }}
               </div>
-            </div>
+            {% endfor %}
           </div>
-        {% endif %}
-      {% endnocache %}
-
-    {% endcache %}
+        </div>
+      </div>
+    {% endif %}
 
     {% block full_content %}
     {% endblock %}

--- a/chicago/templates/committee.html
+++ b/chicago/templates/committee.html
@@ -1,7 +1,6 @@
 {% extends "base_with_margins.html" %}
 {% load extras chicago_extras %}
 {% load static %}
-{% load adv_cache %}
 {% block title %}{{committee.name}}{% endblock %}
 {% block content %}
 

--- a/chicago/templates/committees.html
+++ b/chicago/templates/committees.html
@@ -1,136 +1,131 @@
 {% extends "base_with_margins.html" %}
 {% load extras %}
 {% load static %}
-{% load adv_cache %}
 {% block title %}{{CITY_COUNCIL_NAME}} Committees{% endblock %}
 {% block content %}
 
-  {% cache 600 committees_wrapper 'committees' %}
-
-    <div class="row-fluid">
-      <div class="col-sm-12">
-        <br />
-        <h1>City Council Committees</h1>
-        <hr />
-      </div>
+  <div class="row-fluid">
+    <div class="col-sm-12">
+      <br />
+      <h1>City Council Committees</h1>
+      <hr />
     </div>
+  </div>
 
-    <div class="row-fluid">
-      <div class="col-sm-8 table-col">
+  <div class="row-fluid">
+    <div class="col-sm-8 table-col">
 
+      <div class="table-responsive">
+        <table class='table' id='committees'>
+          <thead>
+            <tr>
+              <th>Committee</th>
+              <th>Chairperson(s)</th>
+              <th>Members</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for committee in committees %}
+              <tr>
+                <td align="left">
+                  <a href="/committee/{{committee.slug}}/">{{ committee.name | committee_topic_only }}</a>
+                </td>
+                <td align="left">
+                  {% for chair in committee.chairs.all %}
+                    {{chair.person}}<br />
+                  {% endfor %}
+                </td>
+                <td>{{ committee.all_members | length }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      {% if subcommittees %}
+        <h2>Subcommittees</h2>
         <div class="table-responsive">
-          <table class='table' id='committees'>
+          <table class='table' id='subcommittees'>
             <thead>
               <tr>
-                <th>Committee</th>
+                <th>Subcommittee</th>
                 <th>Chairperson(s)</th>
                 <th>Members</th>
               </tr>
             </thead>
             <tbody>
-              {% for committee in committees %}
-                <tr>
-                  <td align="left">
-                    <a href="/committee/{{committee.slug}}/">{{ committee.name | committee_topic_only }}</a>
-                  </td>
-                  <td align="left">
-                    {% for chair in committee.chairs.all %}
-                      {{chair.person}}<br />
-                    {% endfor %}
-                  </td>
-                  <td>{{ committee.all_members | length }}</td>
-                </tr>
+              {% for committee in subcommittees %}
+                {% if committee.memberships.all|length > 0 %}
+                  <tr>
+                    <td>
+                      <a href="/committee/{{committee.slug}}/">{{ committee.name | committee_topic_only}}</a>
+                    </td>
+                    <td>
+                      {% for chair in committee.chairs.all %}
+                        {{ chair.person | safe }}<br />
+                      {% endfor %}
+                    </td>
+                    <td>{{ committee.memberships.all | length }}</td>
+                  </tr>
+                {% endif %}
               {% endfor %}
             </tbody>
           </table>
         </div>
-
-        {% if subcommittees %}
-          <h2>Subcommittees</h2>
-          <div class="table-responsive">
-            <table class='table' id='subcommittees'>
-              <thead>
-                <tr>
-                  <th>Subcommittee</th>
-                  <th>Chairperson(s)</th>
-                  <th>Members</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for committee in subcommittees %}
-                  {% if committee.memberships.all|length > 0 %}
-                    <tr>
-                      <td>
-                        <a href="/committee/{{committee.slug}}/">{{ committee.name | committee_topic_only}}</a>
-                      </td>
-                      <td>
-                        {% for chair in committee.chairs.all %}
-                          {{ chair.person | safe }}<br />
-                        {% endfor %}
-                      </td>
-                      <td>{{ committee.memberships.all | length }}</td>
-                    </tr>
-                  {% endif %}
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        {% endif %}
+      {% endif %}
 
 
-        {% if taskforces %}
-          <h2>Task Forces</h2>
-          <div class="table-responsive">
-            <table class='table' id='taskforces'>
-              <thead>
-                <tr>
-                  <th>Task Force</th>
-                  <th>Chairperson(s)</th>
-                  <th>Members</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for committee in taskforces %}
-                  {% if committee.memberships.all|length > 0 %}
-                    <tr>
-                      <td>
-                        <a href="/committee/{{committee.slug}}/">{{ committee.name }}</a>
-                      </td>
-                      <td>
-                        {% for chair in committee.chairs.all %}
-                          {{ chair.person.link_html | safe }}<br />
-                        {% endfor %}
-                      </td>
-                      <td>{{ committee.memberships.all | length }}</td>
-                    </tr>
-                  {% endif %}
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        {% endif %}
-
-      </div>
-
-
-      <div class="col-sm-4">
-        <div class='well info-blurb'>
-          <h4><i class='fa fa-fw fa-info-circle'></i> What do committees do?</h4>
-
-          {{ ABOUT_BLURBS.COMMITTEES | safe }}
-
-          {% if taskforces %}
-            <p>{{CITY_COUNCIL_NAME}} is currently composed of {{committees | length }} Committees, {{subcommittees | length }} Subcommittees and {{taskforces | length }} Task Forces.</p>
-          {% else %}
-            <p>{{CITY_COUNCIL_NAME}} is currently composed of {{committees | length }} Committees{% if subcommittees %} and {{subcommittees | length }} Subcommittees{% endif %}.</p>
-          {% endif %}
-
-          <p><a href='/about/#about-city-council'>More on how City Council works &raquo;</a></p>
+      {% if taskforces %}
+        <h2>Task Forces</h2>
+        <div class="table-responsive">
+          <table class='table' id='taskforces'>
+            <thead>
+              <tr>
+                <th>Task Force</th>
+                <th>Chairperson(s)</th>
+                <th>Members</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for committee in taskforces %}
+                {% if committee.memberships.all|length > 0 %}
+                  <tr>
+                    <td>
+                      <a href="/committee/{{committee.slug}}/">{{ committee.name }}</a>
+                    </td>
+                    <td>
+                      {% for chair in committee.chairs.all %}
+                        {{ chair.person.link_html | safe }}<br />
+                      {% endfor %}
+                    </td>
+                    <td>{{ committee.memberships.all | length }}</td>
+                  </tr>
+                {% endif %}
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
-      </div>
+      {% endif %}
+
     </div>
 
-  {% endcache %}
+
+    <div class="col-sm-4">
+      <div class='well info-blurb'>
+        <h4><i class='fa fa-fw fa-info-circle'></i> What do committees do?</h4>
+
+        {{ ABOUT_BLURBS.COMMITTEES | safe }}
+
+        {% if taskforces %}
+          <p>{{CITY_COUNCIL_NAME}} is currently composed of {{committees | length }} Committees, {{subcommittees | length }} Subcommittees and {{taskforces | length }} Task Forces.</p>
+        {% else %}
+          <p>{{CITY_COUNCIL_NAME}} is currently composed of {{committees | length }} Committees{% if subcommittees %} and {{subcommittees | length }} Subcommittees{% endif %}.</p>
+        {% endif %}
+
+        <p><a href='/about/#about-city-council'>More on how City Council works &raquo;</a></p>
+      </div>
+    </div>
+  </div>
 
 {% endblock %}
 {% block extra_js %}

--- a/chicago/templates/compare_council_members.html
+++ b/chicago/templates/compare_council_members.html
@@ -1,108 +1,103 @@
 {% extends "base_with_margins.html" %}
-{% load static extras chicago_extras adv_cache %}
+{% load static extras chicago_extras %}
 {% block title %}Compare {{CITY_VOCAB.COUNCIL_MEMBERS}}{% endblock %}
 
 {% block content %}
 
-  {% cache 86400 compare_members_wrapper 'compare-members' %}
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-sm-6">
+        <h1>Compare {{ CITY_VOCAB.COUNCIL_MEMBERS }}</h1>
 
-    <div class="container-fluid">
-      <div class="row">
-        <div class="col-sm-6">
-          <h1>Compare {{ CITY_VOCAB.COUNCIL_MEMBERS }}</h1>
+        <p>On February 28, 2023, Chicago will hold a municipal election for Mayor, City Clerk, Treasurer and all 50 City Council Seats. See who is retiring and who is running for re-election and compare their attendance and legislative accomplishments.</p>
 
-          <p>On February 28, 2023, Chicago will hold a municipal election for Mayor, City Clerk, Treasurer and all 50 City Council Seats. See who is retiring and who is running for re-election and compare their attendance and legislative accomplishments.</p>
-
-          <p>Not sure who your Alderman is? <a href="{% url 'council_members' %}">Look them up by your address ></a></p>
-        </div>
-        <div class="col-sm-12">
-          <div class="table-responsive">
-            <table class='table' id='council-members'>
-              <thead>
-                <tr>
-                  <th></th>
-                  <th>{{ CITY_VOCAB.COUNCIL_MEMBER }}</th>
-                  <th>{{CITY_VOCAB.MUNICIPAL_DISTRICT}}</th>
-                  <th>Years in office</th>
-                  <th>Non-routine bills sponsored</th>
-                  <th>Attendance (this session)</th>
-                  <th>Caucus</th>
-                  <th>2023 election status</th>
+        <p>Not sure who your Alderman is? <a href="{% url 'council_members' %}">Look them up by your address ></a></p>
+      </div>
+      <div class="col-sm-12">
+        <div class="table-responsive">
+          <table class='table' id='council-members'>
+            <thead>
+              <tr>
+                <th></th>
+                <th>{{ CITY_VOCAB.COUNCIL_MEMBER }}</th>
+                <th>{{CITY_VOCAB.MUNICIPAL_DISTRICT}}</th>
+                <th>Years in office</th>
+                <th>Non-routine bills sponsored</th>
+                <th>Attendance (this session)</th>
+                <th>Caucus</th>
+                <th>2023 election status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for person in council_members %}
+                <tr id="polygon-{{post.label | slugify}}">
+                  <td>
+                    <div class="thumbnail-square">
+                      <img src='{{person|get_person_headshot}}' alt='{{person.name}}' title='{{person.name}}' class='img-responsive' />
+                    </div>
+                  </td>
+                  <td>
+                    {{ person.link_html | safe }}
+                  </td>
+                  <td>{{ person.latest_council_membership.post.label }}</td>
+                  <td>{{ person.years_in_office }}</td>
+                  <td>
+                    <a href='/search/?q=&selected_facets=sponsorships_exact:{{person.name}}&selected_facets=topics_exact%3ANon-Routine'>
+                      {{ person.statistics.legislation_count }} bills
+                    </a>
+                  </td>
+                  <td>{{ person.statistics.attendance_percent }}</td>
+                  <td>{{ person.caucus }}</td>
+                  <td class="{% if person.election_status %}danger{% else %}info{% endif %}">
+                    {% if person.election_status %}
+                      <i class='fa fa-fw fa-times'></i> {{ person.election_status }}
+                    {% else %}
+                      <i class='fa fa-fw fa-check'></i> Running for re-election
+                    {% endif %}
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for person in council_members %}
-                  <tr id="polygon-{{post.label | slugify}}">
-                    <td>
-                      <div class="thumbnail-square">
-                        <img src='{{person|get_person_headshot}}' alt='{{person.name}}' title='{{person.name}}' class='img-responsive' />
-                      </div>
-                    </td>
-                    <td>
-                      {{ person.link_html | safe }}
-                    </td>
-                    <td>{{ person.latest_council_membership.post.label }}</td>
-                    <td>{{ person.years_in_office }}</td>
-                    <td>
-                      <a href='/search/?q=&selected_facets=sponsorships_exact:{{person.name}}&selected_facets=topics_exact%3ANon-Routine'>
-                        {{ person.statistics.legislation_count }} bills
-                      </a>
-                    </td>
-                    <td>{{ person.statistics.attendance_percent }}</td>
-                    <td>{{ person.caucus }}</td>
-                    <td class="{% if person.election_status %}danger{% else %}info{% endif %}">
-                      {% if person.election_status %}
-                        <i class='fa fa-fw fa-times'></i> {{ person.election_status }}
-                      {% else %}
-                        <i class='fa fa-fw fa-check'></i> Running for re-election
-                      {% endif %}
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
+
       </div>
     </div>
+  </div>
 
-  {% endcache %}
 {% endblock %}
 
 {% block extra_js %}
-  {% cache 86400 js_wrapper 'js' %}
-    <script src="{% static 'js/jquery.dataTables.min.js' %}"></script>
-    <script src="{% static 'js/jquery.dataTables.sorting.js' %}"></script>
-    <script src="{% static 'js/dataTables.bootstrap.js' %}"></script>
+  <script src="{% static 'js/jquery.dataTables.min.js' %}"></script>
+  <script src="{% static 'js/jquery.dataTables.sorting.js' %}"></script>
+  <script src="{% static 'js/dataTables.bootstrap.js' %}"></script>
 
-    <script>
-      var council_member_table = $("#council-members").DataTable({
-        "info": false,
-        "searching": true,
-        "bLengthChange": false,
-        "paging": false,
-        "aaSorting": [ [2,'asc'] ],
-        "aoColumns": [
-          { "bSortable": false },
-          null,
-          { "sType": "num-html" },
-          { "sType": "num-html" },
-          { "sType": "num-html" },
-          null,
-          null,
-          null
-        ]
+  <script>
+    var council_member_table = $("#council-members").DataTable({
+      "info": false,
+      "searching": true,
+      "bLengthChange": false,
+      "paging": false,
+      "aaSorting": [ [2,'asc'] ],
+      "aoColumns": [
+        { "bSortable": false },
+        null,
+        { "sType": "num-html" },
+        { "sType": "num-html" },
+        { "sType": "num-html" },
+        null,
+        null,
+        null
+      ]
+    });
+
+    $( document ).ready(function() {
+      $('.thumbnail-square img').each(function() {
+        if ($(this).width() > $(this).height()) {
+          $(this).addClass('landscape');
+        }
       });
+    });
+  </script>
 
-      $( document ).ready(function() {
-        $('.thumbnail-square img').each(function() {
-          if ($(this).width() > $(this).height()) {
-            $(this).addClass('landscape');
-          }
-        });
-      });
-    </script>
-
-  {% endcache %}
 {% endblock %}

--- a/chicago/templates/council_members.html
+++ b/chicago/templates/council_members.html
@@ -1,119 +1,110 @@
 {% extends "base_with_margins.html" %}
 {% load static %}
-{% load adv_cache %}
 {% block title %}{{CITY_COUNCIL_NAME}} Members{% endblock %}
 
 {% block extra_css %}
-  {% cache 86400 leaflet_wrapper 'leaflet' %}
-    {% if map_geojson %}
-      <link rel="stylesheet" href="{% static 'css/leaflet.css' %}" />
-    {% endif %}
-  {% endcache %}
+  {% if map_geojson %}
+    <link rel="stylesheet" href="{% static 'css/leaflet.css' %}" />
+  {% endif %}
 {% endblock %}
 
 {% block content %}
 
-  {% cache 86400 members_wrapper 'members' %}
-
-    <div class="container-fluid">
-      <div class="row">
-        <div class="col-sm-6">
-          <h1>{{ CITY_VOCAB.COUNCIL_MEMBERS }}</h1>
-          <h4>Look up your council member</h4>
-          <div class="input-group address-search">
-            <input name="search_address" id='search_address' type="text" class="form-control" placeholder="Enter your address">
-            <div class='input-group-btn'>
-              <button id='btn_search' class="btn btn-primary" title='Search'>
-                <i class='fa fa-fw fa-search'></i><span class="non-mobile-only"> Search</span>
-              </button>
-              <a class='btn btn-default' id='reset' title='Reset the map' href='#'>
-                <i class='glyphicon glyphicon-repeat'></i> Reset
-              </a>
-            </div>
-          </div>
-          <div id="council-member-scroll-area">
-            {% include 'partials/council_member_table.html' %}
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-sm-6">
+        <h1>{{ CITY_VOCAB.COUNCIL_MEMBERS }}</h1>
+        <h4>Look up your council member</h4>
+        <div class="input-group address-search">
+          <input name="search_address" id='search_address' type="text" class="form-control" placeholder="Enter your address">
+          <div class='input-group-btn'>
+            <button id='btn_search' class="btn btn-primary" title='Search'>
+              <i class='fa fa-fw fa-search'></i><span class="non-mobile-only"> Search</span>
+            </button>
+            <a class='btn btn-default' id='reset' title='Reset the map' href='#'>
+              <i class='glyphicon glyphicon-repeat'></i> Reset
+            </a>
           </div>
         </div>
-        <div class='col-sm-6 hidden-xs'>
-          <div id="map"></div>
+        <div id="council-member-scroll-area">
+          {% include 'partials/council_member_table.html' %}
         </div>
       </div>
+      <div class='col-sm-6 hidden-xs'>
+        <div id="map"></div>
+      </div>
     </div>
-
-  {% endcache %}
+  </div>
 
 {% endblock %}
 
 
 {% block extra_js %}
-  {% cache 86400 js_wrapper_compare 'js' %}
-    {% include 'partials/map.html' %}
-    <script src="{% static 'js/jquery.dataTables.min.js' %}"></script>
-    <script src="{% static 'js/jquery.dataTables.sorting.js' %}"></script>
-    <script src="{% static 'js/dataTables.bootstrap.js' %}"></script>
+  {% include 'partials/map.html' %}
+  <script src="{% static 'js/jquery.dataTables.min.js' %}"></script>
+  <script src="{% static 'js/jquery.dataTables.sorting.js' %}"></script>
+  <script src="{% static 'js/dataTables.bootstrap.js' %}"></script>
 
-    <script>
-      var council_member_table = $("#council-members").DataTable({
-        "info": false,
-        "bLengthChange": false,
-        "paging": false,
-        "aaSorting": [ [2,'asc'] ],
-        "aoColumns": [
-          { "bSortable": false },
-          null,
-          { "sType": "num-html" }
-        ]
+  <script>
+    var council_member_table = $("#council-members").DataTable({
+      "info": false,
+      "bLengthChange": false,
+      "paging": false,
+      "aaSorting": [ [2,'asc'] ],
+      "aoColumns": [
+        { "bSortable": false },
+        null,
+        { "sType": "num-html" }
+      ]
+    });
+
+    $( document ).ready(function() {
+      $('.thumbnail-square img').each(function() {
+        if ($(this).width() > $(this).height()) {
+          $(this).addClass('landscape');
+        }
       });
+    });
 
-      $( document ).ready(function() {
-        $('.thumbnail-square img').each(function() {
-          if ($(this).width() > $(this).height()) {
-            $(this).addClass('landscape');
+
+    {% if map_geojson %}
+      $('tbody tr').on( 'mouseover', function () {
+        hoverOnRow(this.id);
+        $('tr').css('background-color', 'inherit')
+        $(this).css('background-color', '#eee');
+      } );
+
+      $('tbody tr').on( "mouseout", function() {
+        $('tr').css('background-color', 'inherit');
+        hoverOffRow(this.id);
+      } )
+
+      function hoverOffRow(select_id){
+        districts.eachLayer(function (layer) {
+
+          if (layer.feature.properties.select_id === select_id){
+            layer.fire('tableout');
           }
+
         });
-      });
+
+      }
+
+      function hoverOnRow(select_id) {
+        districts.eachLayer(function (layer) {
+
+          layer.setStyle({'fillOpacity': .2})
 
 
-      {% if map_geojson %}
-        $('tbody tr').on( 'mouseover', function () {
-          hoverOnRow(this.id);
-          $('tr').css('background-color', 'inherit')
-          $(this).css('background-color', '#eee');
-        } );
+          if (layer.feature.properties.select_id === select_id){
+            layer.fire('tableover');
+          }
 
-        $('tbody tr').on( "mouseout", function() {
-          $('tr').css('background-color', 'inherit');
-          hoverOffRow(this.id);
-        } )
+        });
+      }
 
-        function hoverOffRow(select_id){
-          districts.eachLayer(function (layer) {
+    {% endif %}
 
-            if (layer.feature.properties.select_id === select_id){
-              layer.fire('tableout');
-            }
+  </script>
 
-          });
-
-        }
-
-        function hoverOnRow(select_id) {
-          districts.eachLayer(function (layer) {
-
-            layer.setStyle({'fillOpacity': .2})
-
-
-            if (layer.feature.properties.select_id === select_id){
-              layer.fire('tableover');
-            }
-
-          });
-        }
-
-      {% endif %}
-
-    </script>
-
-  {% endcache %}
 {% endblock %}

--- a/chicago/templates/divided_votes.html
+++ b/chicago/templates/divided_votes.html
@@ -1,127 +1,122 @@
 {% extends "base_with_margins.html" %}
-{% load static extras chicago_extras adv_cache %}
+{% load static extras chicago_extras %}
 {% block title %}Divided Votes{% endblock %}
 
 {% block content %}
 
-  {% cache 86400 split_votes_wrapper 'split-votes' %}
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-sm-8">
+        <h1>Divided Votes - {{ legislative_session.name }}</h1>
 
-    <div class="container-fluid">
-      <div class="row">
-        <div class="col-sm-8">
-          <h1>Divided Votes - {{ legislative_session.name }}</h1>
+        <p>For the {{ legislative_session.name }} of Chicago City Council under <strong>Mayor {{legislative_session.identifier|get_mayor}}</strong>, there have been <strong>{{bills|length}} votes</strong> with any dissenting "No" votes (sometimes referred to as a divided roll call). Everything else has either been held in committee with no vote or is considered noncontroversial and has passed unanimously.</p>
 
-          <p>For the {{ legislative_session.name }} of Chicago City Council under <strong>Mayor {{legislative_session.identifier|get_mayor}}</strong>, there have been <strong>{{bills|length}} votes</strong> with any dissenting "No" votes (sometimes referred to as a divided roll call). Everything else has either been held in committee with no vote or is considered noncontroversial and has passed unanimously.</p>
-
-          <p>Filter by legislative term:
-            {% for term in legislative_session_options %}
-              <a href="/divided-votes/{{term}}/" class="btn btn-primary {% if legislative_session.identifier == term %}active{% endif %}">{{term}}</a>
-            {% endfor %}
-          </p>
-        </div>
-        <div class="col-sm-12">
-          <div class="table-responsive">
-            <table class='table' id='split-votes'>
-              <thead>
+        <p>Filter by legislative term:
+          {% for term in legislative_session_options %}
+            <a href="/divided-votes/{{term}}/" class="btn btn-primary {% if legislative_session.identifier == term %}active{% endif %}">{{term}}</a>
+          {% endfor %}
+        </p>
+      </div>
+      <div class="col-sm-12">
+        <div class="table-responsive">
+          <table class='table' id='split-votes'>
+            <thead>
+              <tr>
+                <th>Legislation</th>
+                <th>Primary sponsor</th>
+                <th>Topics</th>
+                <th>Date of last action</th>
+                <th>Status</th>
+                <th>Votes for</th>
+                <th>Votes against</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for legislation in bills %}
                 <tr>
-                  <th>Legislation</th>
-                  <th>Primary sponsor</th>
-                  <th>Topics</th>
-                  <th>Date of last action</th>
-                  <th>Status</th>
-                  <th>Votes for</th>
-                  <th>Votes against</th>
+                  <td>
+                    <p class='h4'><a href="{% url 'bill_detail' legislation.slug %}">{{ legislation.friendly_name }}</a></p>
+                    {{ legislation.listing_description | short_blurb }}
+                  </td>
+                  <td class="nowrap">
+                    {{legislation.primary_sponsor.person.name}}
+                  </td>
+                  <td>
+                    {% if legislation.topics %}
+                      <i class="fa fa-fw fa-tag"></i>
+                      {% for tag in legislation.topics %}
+                        <span class="badge badge-muted pseudo-topic-tag">
+                          <a href='/search/?q=&selected_facets=topics_exact:{{ tag }}'>{{ tag }}</a>
+                        </span>
+                      {% endfor %}
+                      <br/>
+                    {% else %}
+                      <i class="fa fa-fw fa-tag"></i>
+                      {% for tag in legislation.pseudo_topics %}
+                        <span class="badge badge-muted pseudo-topic-tag">
+                          <a href='/search/?q=&selected_facets=topics_exact:{{ tag | committee_topic_only}}'>{{ tag | committee_topic_only }}</a>
+                        </span>
+                      {% endfor %}
+                      <br/>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% firstof legislation.last_action_date|date:'n/d/Y' legislation.get_last_action_date|date:'n/d/Y' %}
+                  </td>
+                  <td>
+                    {{ legislation.inferred_status | inferred_status_label | safe }}
+                  </td>
+                  <td>
+                    {% for vote_event in legislation.votes.all %}
+                      {% for count in vote_event.counts.all %}
+                        {% if count.option == 'yes' %}
+                          {{count.value}}
+                        {% endif %}
+                      {% endfor %}
+                    {% endfor %}
+                  </td>
+                  <td>
+                    {% for vote_event in legislation.votes.all %}
+                      {% for count in vote_event.counts.all %}
+                        {% if count.option == 'no' %}
+                          {{count.value}}
+                        {% endif %}
+                      {% endfor %}
+                    {% endfor %}
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for legislation in bills %}
-                  <tr>
-                    <td>
-                      <p class='h4'><a href="{% url 'bill_detail' legislation.slug %}">{{ legislation.friendly_name }}</a></p>
-                      {{ legislation.listing_description | short_blurb }}
-                    </td>
-                    <td class="nowrap">
-                      {{legislation.primary_sponsor.person.name}}
-                    </td>
-                    <td>
-                      {% if legislation.topics %}
-                        <i class="fa fa-fw fa-tag"></i>
-                        {% for tag in legislation.topics %}
-                          <span class="badge badge-muted pseudo-topic-tag">
-                            <a href='/search/?q=&selected_facets=topics_exact:{{ tag }}'>{{ tag }}</a>
-                          </span>
-                        {% endfor %}
-                        <br/>
-                      {% else %}
-                        <i class="fa fa-fw fa-tag"></i>
-                        {% for tag in legislation.pseudo_topics %}
-                          <span class="badge badge-muted pseudo-topic-tag">
-                            <a href='/search/?q=&selected_facets=topics_exact:{{ tag | committee_topic_only}}'>{{ tag | committee_topic_only }}</a>
-                          </span>
-                        {% endfor %}
-                        <br/>
-                      {% endif %}
-                    </td>
-                    <td>
-                      {% firstof legislation.last_action_date|date:'n/d/Y' legislation.get_last_action_date|date:'n/d/Y' %}
-                    </td>
-                    <td>
-                      {{ legislation.inferred_status | inferred_status_label | safe }}
-                    </td>
-                    <td>
-                      {% for vote_event in legislation.votes.all %}
-                        {% for count in vote_event.counts.all %}
-                          {% if count.option == 'yes' %}
-                            {{count.value}}
-                          {% endif %}
-                        {% endfor %}
-                      {% endfor %}
-                    </td>
-                    <td>
-                      {% for vote_event in legislation.votes.all %}
-                        {% for count in vote_event.counts.all %}
-                          {% if count.option == 'no' %}
-                            {{count.value}}
-                          {% endif %}
-                        {% endfor %}
-                      {% endfor %}
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
+  </div>
 
-  {% endcache %}
 {% endblock %}
 
 {% block extra_js %}
-  {% cache 86400 js_wrapper_divided_votes 'js' %}
-    <script src="{% static 'js/jquery.dataTables.min.js' %}"></script>
-    <script src="{% static 'js/jquery.dataTables.sorting.js' %}"></script>
-    <script src="{% static 'js/dataTables.bootstrap.js' %}"></script>
+  <script src="{% static 'js/jquery.dataTables.min.js' %}"></script>
+  <script src="{% static 'js/jquery.dataTables.sorting.js' %}"></script>
+  <script src="{% static 'js/dataTables.bootstrap.js' %}"></script>
 
-    <script>
-      var council_member_table = $("#split-votes").DataTable({
-        "info": false,
-        "searching": true,
-        "bLengthChange": false,
-        "paging": false,
-        "aaSorting": [ [3,'desc'] ],
-        "aoColumns": [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
-        ]
-      });
-    </script>
+  <script>
+    var council_member_table = $("#split-votes").DataTable({
+      "info": false,
+      "searching": true,
+      "bLengthChange": false,
+      "paging": false,
+      "aaSorting": [ [3,'desc'] ],
+      "aoColumns": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    });
+  </script>
 
-  {% endcache %}
 {% endblock %}

--- a/chicago/templates/index.html
+++ b/chicago/templates/index.html
@@ -1,323 +1,320 @@
 {% extends "base.html" %}
 {% load static %}
-{% load adv_cache %}
 {% block title %}Chicago City Council, demystified{% endblock %}
 
 {% block full_content %}
-  {% cache 86400 index_wrapper 'index' %}
-    <div class="container-fluid" id="section-photo">
-      <div class="row-fluid">
-        <div class='col-sm-10 col-sm-offset-1'>
-          <br/>
-          <h2>
-            <h1>{{ CITY_COUNCIL_NAME }}, demystified</h1>
-          </h2>
-          <br/>
+  <div class="container-fluid" id="section-photo">
+    <div class="row-fluid">
+      <div class='col-sm-10 col-sm-offset-1'>
+        <br/>
+        <h2>
+          <h1>{{ CITY_COUNCIL_NAME }}, demystified</h1>
+        </h2>
+        <br/>
 
-          <p class="h3 no-pad-top">
-            <span>Search {{CITY_NAME}} legislation</span>
-          </p>
+        <p class="h3 no-pad-top">
+          <span>Search {{CITY_NAME}} legislation</span>
+        </p>
 
-          <form class="search form-search=" action="/search/" method="GET">
-            <div class="input-group site-intro-search">
-              <input name="q" type="text" class="input-lg form-control" placeholder="{{SEARCH_PLACEHOLDER_TEXT}}">
-              <div class='input-group-btn'>
-                <button type="submit" class="btn btn-lg btn-primary">
-                  <i class='fa fa-fw fa-search'></i>
-                </button>
-              </div>
-            </div>
-          </form>
-
-          <div class="divider"></div>
-        </div>
-      </div>
-    </div>
-    <div class="container-fluid" id="section-intro">
-      <div class="row-fluid">
-        <div class='col-sm-10 col-sm-offset-1'>
-          <div class="divider"></div>
-
-          <div class='row'>
-            <div class='col-sm-6'>
-              <p>Chicago City Council consists of <a href='/council-members/'>50 elected aldermen</a> and meets monthly to shape the city. The council works with <a href='/person/lightfoot-lori-e-f6faf37c9643/' >Lori Lightfoot</a>, the Mayor, and <a href='/person/valencia-anna-m-257a68ccbc17/'>Anna Valencia</a>, the City Clerk.</p>
-
-              <p>
-                <strong>Chicago Councilmatic</strong> tracks all things related to Chicago City Council:
-                <ul>
-                  <li>
-                    the <a href='/search/'>legislation</a> introduced and passed
-                  </li>
-                  <li>
-                    its various <a href='/committees/'>committees</a> and the <a href='/events/'  >meetings</a> they hold
-                  </li>
-                  <li>
-                    the <a href='/council-members/'>aldermen</a> themselves
-                  </li>
-                </ul>
-              </p>
-              <p>
-                <span>
-                  <a href='/about#about-city-council'>More on how City Council works &raquo;</a>
-                </span>
-
-              </p>
-            </div>
-
-            <div class= 'col-sm-2'>
-              <p>
-                <a href='/council-members/'><img src='/static/images/chicago_map.jpg' class='img-responsive img-thumbnail' alt="Find your Alderman" /></a>
-              </p>
-              <p>
-                <a class="btn btn-primary" href="{% url 'council_members' %}">Find your Alderman <i class="fa fa-fw fa-chevron-right"></i></a>
-              </p>
-            </div>
-            <div class= 'col-sm-2 col-sm-offset-1'>
-              <p>
-                <a href='/compare-council-members/'><img src='/static/images/compare-aldermen.jpg' class='img-responsive img-thumbnail' alt="Compare Alderman" /></a>
-              </p>
-              <p>
-                <a class="btn btn-primary" href="/compare-council-members/">Compare Aldermen <i class="fa fa-fw fa-chevron-right"></i></a>
-              </p>
+        <form class="search form-search=" action="/search/" method="GET">
+          <div class="input-group site-intro-search">
+            <input name="q" type="text" class="input-lg form-control" placeholder="{{SEARCH_PLACEHOLDER_TEXT}}">
+            <div class='input-group-btn'>
+              <button type="submit" class="btn btn-lg btn-primary">
+                <i class='fa fa-fw fa-search'></i>
+              </button>
             </div>
           </div>
+        </form>
 
-          <div class="divider"></div>
-
-        </div>
+        <div class="divider"></div>
       </div>
     </div>
+  </div>
+  <div class="container-fluid" id="section-intro">
+    <div class="row-fluid">
+      <div class='col-sm-10 col-sm-offset-1'>
+        <div class="divider"></div>
 
-    <div class="container-fluid" id="section-engage">
-      <div class="row-fluid">
-        <div class='col-sm-10 col-sm-offset-1'>
-          <h2>
-            <span>
-              <i class="fa fa-institution"></i>
-              Engage City Council
-            </span>
-          </h2>
+        <div class='row'>
+          <div class='col-sm-6'>
+            <p>Chicago City Council consists of <a href='/council-members/'>50 elected aldermen</a> and meets monthly to shape the city. The council works with <a href='/person/lightfoot-lori-e-f6faf37c9643/' >Lori Lightfoot</a>, the Mayor, and <a href='/person/valencia-anna-m-257a68ccbc17/'>Anna Valencia</a>, the City Clerk.</p>
 
-          <div class='row'>
-            <div class='col-sm-6'>
-              <h4>Citywide issues</h4>
-              <p>The Mayor proposes most city-wide policies. These include <a href='/search/?q=&selected_facets=topics_exact:City Business'>business transactions</a>, changes to the <a href='/search/?q=&selected_facets=topics_exact:Municipal Code'>municipal code</a>, <a href='/search/?q=&selected_facets=topics_exact:Bonds'>bond issuance</a> and <a href='/search/?q=&selected_facets=topics_exact:Appointment'>appointments</a>.</p>
-
-              <p>
-                <a class='btn btn-primary' href='/search/?q=&selected_facets=topics_exact:City Matters'>
-                  View citywide legislation <i class="fa fa-fw fa-chevron-right"></i>
-                </a>
-              </p>
-              <br/>
-            </div>
-            <div class='col-sm-6'>
-              <h4>Local issues</h4>
-              <p>At the local level, matters like <a href='/search/?q=&selected_facets=topics_exact:Land Use'>land use</a>, <a href='/search/?q=&selected_facets=topics_exact:Sign permits'>signs</a>, <a href='/search/?q=&selected_facets=topics_exact:Parking'>street parking</a>, <a href='/search/?q=&selected_facets=topics_exact:Business Permits and Privileges'>business permits</a>, and other <a href='/search/?q=&selected_facets=topics_exact:Residents'>residents issues</a> require the local Alderman's support.</p>
-
-              <p>
-                <a class='btn btn-primary' href='/council-members/'>
-                  Find your alderman <i class="fa fa-fw fa-chevron-right"></i>
-                </a>
-              </p>
-              <br/>
-            </div>
-            <div class="divider"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="container-fluid" id="section-events">
-      <div class="row-fluid">
-        <div class='col-sm-10 col-sm-offset-1'>
-
-          {% if next_council_meeting or upcoming_committee_meetings %}
-            <h2>
-              <i class="fa fa-fw fa-calendar-o"></i>
-              Upcoming Meetings
-            </h2>
-            <br/>
-
-            {% if next_council_meeting %}
-
-              <h4><i class="fa fa-fw fa-institution"></i> Next City Council meeting</h4>
-
-              <p class="small text-muted">
-                <i class="fa fa-fw fa-calendar-o"></i> {{next_council_meeting.start_time | date:"D n/d/Y"}}<br/>
-                <i class="fa fa-fw fa-clock-o"></i> {{next_council_meeting.start_time| date:"g:ia"}}<br/>
-                <i class="fa fa-fw fa-map-marker"></i> Council Chambers, City Hall<br />
-                <i class="fa fa-fw"></i> 121 N LaSalle St, Chicago, IL
-              </p>
-              <a class='btn btn-info btn-sm' href="{{next_council_meeting.event_page_url}}">
-                Details
-                <i class="fa fa-fw fa-chevron-right"></i>
-              </a>
-              <br/><br/>
-
-            {% endif %}
-
-            {% if upcoming_committee_meetings %}
-              <h4>
-                Committee meetings
-              </h4>
-              {% for event in upcoming_committee_meetings %}
-                <p class="no-pad-bottom small">
-                  {{event.start_time | date:"D"}}
-                  {{event.start_time | date:"m/d"}} -
-
-                  {{ event.link_html | safe }}
-
-                </p>
-              {% endfor %}
-              <br/>
-              <a href="/events/" class="btn btn-sm btn-info">
-                All upcoming events
-                <i class="fa fa-fw fa-chevron-right"></i>
-              </a>
-            {% endif %}
-          {% endif %}
-
-          <div class="divider"></div>
-        </div>
-      </div>
-    </div>
-
-    <div class="container-fluid" id="section-last-council-meeting">
-      <div class="row-fluid">
-        <div class='col-sm-10 col-sm-offset-1'>
-          <h2>
-            <i class="fa fa-fw fa-users"></i>Latest Council Meeting
-          </h2>
-
-          <p class="big">
-            At the <a href="{{last_council_meeting.event_page_url}}"><strong>latest City Council meeting</strong></a> on {{last_council_meeting.start_time | date:"M jS"}}, council members took action on <strong>{{council_bills | length}}</strong> pieces of legislation, including <strong>{{nonroutine_council_bills | length}}</strong> that are <a href="/search/?q=&selected_facets=topics_exact:Non-Routine">non-routine</a>.
-          </p>
-
-          <p>
-            One of the more unusual aspects of Chicago City Council is the volume of ordinances that are introduced and passed every month. Most of these are routine items like <a href='/search/?q=&selected_facets=topics_exact:Sign%20permits'>sign permits</a>, <a href='/search/?q=&selected_facets=topics_exact:Damage to vehicle claim'>damaged vehicle claims</a>, <a href='/search/?q=&selected_facets=topics_exact:Sidewalk cafe'>sidewalk cafe approvals</a> and <a href='/search/?q=&selected_facets=topics_exact:Honorifics'>honorifics</a>.
-          </p>
-
-          <p>
-            To help sort through all of this, we classify all legislation and tag it appropriately. If something doesn’t look like a routine piece of legislation, we tag it as <a href='/search/?q=&selected_facets=topics_exact:Non-Routine'>Non-Routine</a> to make it easier to discover.
-          </p>
-
-          <div class="divider"></div>
-        </div>
-      </div>
-      <div class="row-fluid">
-        <div class='col-sm-6 col-sm-offset-1'>
-          <h3>
-            Non-Routine Activity
-          </h3>
-          {% for legislation in nonroutine_council_bills %}
-            <div class="bill-meeting">
-              {% include "partials/legislation_item.html" %}
-            </div>
-          {% endfor %}
-          {% if nonroutine_council_bills|length > 4%}
-            <a href="" id="more-bills-meeting" class="btn btn-info"><i class="fa fa-fw fa-chevron-down"></i>Show more</a>
-            <a href="" id="fewer-bills-meeting" class="btn btn-info"><i class="fa fa-fw fa-chevron-up"></i>Show fewer</a>
-          {% endif %}
-          <div class="divider"></div>
-        </div>
-
-        <div class='col-sm-4'>
-          <h3>
-            Legislative topics
-          </h3>
-
-          {% for parent in topic_hierarchy %}
-
-            <div id="accordion-{{parent.name|slugify}}" class="topic-hierarchy">
-              <div class="panel panel-default panel-filter">
-                <div class="panel-heading" href="#collapse-{{parent.name|slugify}}" data-parent="#accordion-{{parent.name|slugify}}" data-toggle="collapse">
-                  <i class="fa fa-lg plusminus fa-plus pull-right"></i>
-                  <span class="badge badge-default">{{parent.count}}</span> {{parent.name}}
-                </div>
-                <div id="collapse-{{parent.name|slugify}}" class="panel-collapse collapse">
-                  <div class="panel-body">
-                    {% for child in parent.children %}
-                      <p class="no-pad-bottom">
-                        {% if child.count == 0 %}
-                          <span class="badge badge-default-light">{{child.count}}</span>
-                        {% else %}
-                          <span class="badge badge-default">{{child.count}}</span>
-                        {% endif %}
-                        <a href="/search/?q=&selected_facets=topics_exact:{{child.name}}">
-                          {{child.name}}
-                        </a>
-                      </p>
-                      <ul>
-                        {% for grandchild in child.children %}
-                          <li class="small">
-                            {% if grandchild.count == 0 %}
-                              <span class="badge badge-default-light">{{grandchild.count}}</span>
-                            {% else %}
-                              <span class="badge badge-default">{{grandchild.count}}</span>
-                            {% endif %}
-                            <a href="/search/?q=&selected_facets=topics_exact:{{grandchild.name}}">
-                              {{grandchild.name}}
-                            </a>
-                          </li>
-                        {% endfor %}
-                      </ul>
-                    {% endfor %}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-
-          {% endfor %}
-
-
-        </div>
-
-      </div>
-    </div>
-
-
-    {% if recent_bills %}
-      <div class="container-fluid" id="section-recent-activity">
-        <div class="row-fluid">
-          <div class='col-sm-10 col-sm-offset-1'>
-            <div class="divider"></div>
-            <h2>
-              <i class="fa fa-fw fa-clock-o"></i>Since the last council meeting
-            </h2>
             <p>
-              After {{last_council_meeting.start_time | date:"M jS"}}, City Council introduced
-              <strong>{{recent_bills | length}}</strong> new pieces of legislation, including <strong>{{nonroutine_recent_bills | length}}</strong> that are
-              <a href="/search/?q=&selected_facets=topics_exact:Non-Routine">non-routine</a>.
+              <strong>Chicago Councilmatic</strong> tracks all things related to Chicago City Council:
+              <ul>
+                <li>
+                  the <a href='/search/'>legislation</a> introduced and passed
+                </li>
+                <li>
+                  its various <a href='/committees/'>committees</a> and the <a href='/events/'  >meetings</a> they hold
+                </li>
+                <li>
+                  the <a href='/council-members/'>aldermen</a> themselves
+                </li>
+              </ul>
+            </p>
+            <p>
+              <span>
+                <a href='/about#about-city-council'>More on how City Council works &raquo;</a>
+              </span>
+
+            </p>
+          </div>
+
+          <div class= 'col-sm-2'>
+            <p>
+              <a href='/council-members/'><img src='/static/images/chicago_map.jpg' class='img-responsive img-thumbnail' alt="Find your Alderman" /></a>
+            </p>
+            <p>
+              <a class="btn btn-primary" href="{% url 'council_members' %}">Find your Alderman <i class="fa fa-fw fa-chevron-right"></i></a>
+            </p>
+          </div>
+          <div class= 'col-sm-2 col-sm-offset-1'>
+            <p>
+              <a href='/compare-council-members/'><img src='/static/images/compare-aldermen.jpg' class='img-responsive img-thumbnail' alt="Compare Alderman" /></a>
+            </p>
+            <p>
+              <a class="btn btn-primary" href="/compare-council-members/">Compare Aldermen <i class="fa fa-fw fa-chevron-right"></i></a>
             </p>
           </div>
         </div>
 
-        {% if nonroutine_recent_bills %}
-          <div class="row-fluid">
-            <div class='col-sm-6 col-sm-offset-1'>
-              <h3>
-                Non-routine legislation introduced
-              </h3>
-              {% for legislation in nonroutine_recent_bills %}
-                <div class="bill-recent">
-                  {% include "partials/legislation_item.html" %}
-                </div>
-              {% endfor %}
-              {% if nonroutine_recent_bills|length > 4%}
-                <a href="" id="more-bills-recent" class="btn btn-info"><i class="fa fa-fw fa-chevron-down"></i>Show more</a>
-                <a href="" id="fewer-bills-recent" class="btn btn-info"><i class="fa fa-fw fa-chevron-up"></i>Show fewer</a>
-              {% endif %}
-              <div class="divider"></div>
-            </div>
+        <div class="divider"></div>
 
+      </div>
+    </div>
+  </div>
+
+  <div class="container-fluid" id="section-engage">
+    <div class="row-fluid">
+      <div class='col-sm-10 col-sm-offset-1'>
+        <h2>
+          <span>
+            <i class="fa fa-institution"></i>
+            Engage City Council
+          </span>
+        </h2>
+
+        <div class='row'>
+          <div class='col-sm-6'>
+            <h4>Citywide issues</h4>
+            <p>The Mayor proposes most city-wide policies. These include <a href='/search/?q=&selected_facets=topics_exact:City Business'>business transactions</a>, changes to the <a href='/search/?q=&selected_facets=topics_exact:Municipal Code'>municipal code</a>, <a href='/search/?q=&selected_facets=topics_exact:Bonds'>bond issuance</a> and <a href='/search/?q=&selected_facets=topics_exact:Appointment'>appointments</a>.</p>
+
+            <p>
+              <a class='btn btn-primary' href='/search/?q=&selected_facets=topics_exact:City Matters'>
+                View citywide legislation <i class="fa fa-fw fa-chevron-right"></i>
+              </a>
+            </p>
+            <br/>
           </div>
+          <div class='col-sm-6'>
+            <h4>Local issues</h4>
+            <p>At the local level, matters like <a href='/search/?q=&selected_facets=topics_exact:Land Use'>land use</a>, <a href='/search/?q=&selected_facets=topics_exact:Sign permits'>signs</a>, <a href='/search/?q=&selected_facets=topics_exact:Parking'>street parking</a>, <a href='/search/?q=&selected_facets=topics_exact:Business Permits and Privileges'>business permits</a>, and other <a href='/search/?q=&selected_facets=topics_exact:Residents'>residents issues</a> require the local Alderman's support.</p>
+
+            <p>
+              <a class='btn btn-primary' href='/council-members/'>
+                Find your alderman <i class="fa fa-fw fa-chevron-right"></i>
+              </a>
+            </p>
+            <br/>
+          </div>
+          <div class="divider"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="container-fluid" id="section-events">
+    <div class="row-fluid">
+      <div class='col-sm-10 col-sm-offset-1'>
+
+        {% if next_council_meeting or upcoming_committee_meetings %}
+          <h2>
+            <i class="fa fa-fw fa-calendar-o"></i>
+            Upcoming Meetings
+          </h2>
+          <br/>
+
+          {% if next_council_meeting %}
+
+            <h4><i class="fa fa-fw fa-institution"></i> Next City Council meeting</h4>
+
+            <p class="small text-muted">
+              <i class="fa fa-fw fa-calendar-o"></i> {{next_council_meeting.start_time | date:"D n/d/Y"}}<br/>
+              <i class="fa fa-fw fa-clock-o"></i> {{next_council_meeting.start_time| date:"g:ia"}}<br/>
+              <i class="fa fa-fw fa-map-marker"></i> Council Chambers, City Hall<br />
+              <i class="fa fa-fw"></i> 121 N LaSalle St, Chicago, IL
+            </p>
+            <a class='btn btn-info btn-sm' href="{{next_council_meeting.event_page_url}}">
+              Details
+              <i class="fa fa-fw fa-chevron-right"></i>
+            </a>
+            <br/><br/>
+
+          {% endif %}
+
+          {% if upcoming_committee_meetings %}
+            <h4>
+              Committee meetings
+            </h4>
+            {% for event in upcoming_committee_meetings %}
+              <p class="no-pad-bottom small">
+                {{event.start_time | date:"D"}}
+                {{event.start_time | date:"m/d"}} -
+
+                {{ event.link_html | safe }}
+
+              </p>
+            {% endfor %}
+            <br/>
+            <a href="/events/" class="btn btn-sm btn-info">
+              All upcoming events
+              <i class="fa fa-fw fa-chevron-right"></i>
+            </a>
+          {% endif %}
+        {% endif %}
+
+        <div class="divider"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="container-fluid" id="section-last-council-meeting">
+    <div class="row-fluid">
+      <div class='col-sm-10 col-sm-offset-1'>
+        <h2>
+          <i class="fa fa-fw fa-users"></i>Latest Council Meeting
+        </h2>
+
+        <p class="big">
+          At the <a href="{{last_council_meeting.event_page_url}}"><strong>latest City Council meeting</strong></a> on {{last_council_meeting.start_time | date:"M jS"}}, council members took action on <strong>{{council_bills | length}}</strong> pieces of legislation, including <strong>{{nonroutine_council_bills | length}}</strong> that are <a href="/search/?q=&selected_facets=topics_exact:Non-Routine">non-routine</a>.
+        </p>
+
+        <p>
+          One of the more unusual aspects of Chicago City Council is the volume of ordinances that are introduced and passed every month. Most of these are routine items like <a href='/search/?q=&selected_facets=topics_exact:Sign%20permits'>sign permits</a>, <a href='/search/?q=&selected_facets=topics_exact:Damage to vehicle claim'>damaged vehicle claims</a>, <a href='/search/?q=&selected_facets=topics_exact:Sidewalk cafe'>sidewalk cafe approvals</a> and <a href='/search/?q=&selected_facets=topics_exact:Honorifics'>honorifics</a>.
+        </p>
+
+        <p>
+          To help sort through all of this, we classify all legislation and tag it appropriately. If something doesn’t look like a routine piece of legislation, we tag it as <a href='/search/?q=&selected_facets=topics_exact:Non-Routine'>Non-Routine</a> to make it easier to discover.
+        </p>
+
+        <div class="divider"></div>
+      </div>
+    </div>
+    <div class="row-fluid">
+      <div class='col-sm-6 col-sm-offset-1'>
+        <h3>
+          Non-Routine Activity
+        </h3>
+        {% for legislation in nonroutine_council_bills %}
+          <div class="bill-meeting">
+            {% include "partials/legislation_item.html" %}
+          </div>
+        {% endfor %}
+        {% if nonroutine_council_bills|length > 4%}
+          <a href="" id="more-bills-meeting" class="btn btn-info"><i class="fa fa-fw fa-chevron-down"></i>Show more</a>
+          <a href="" id="fewer-bills-meeting" class="btn btn-info"><i class="fa fa-fw fa-chevron-up"></i>Show fewer</a>
         {% endif %}
         <div class="divider"></div>
       </div>
-    {% endif %}
 
-  {% endcache %}
+      <div class='col-sm-4'>
+        <h3>
+          Legislative topics
+        </h3>
+
+        {% for parent in topic_hierarchy %}
+
+          <div id="accordion-{{parent.name|slugify}}" class="topic-hierarchy">
+            <div class="panel panel-default panel-filter">
+              <div class="panel-heading" href="#collapse-{{parent.name|slugify}}" data-parent="#accordion-{{parent.name|slugify}}" data-toggle="collapse">
+                <i class="fa fa-lg plusminus fa-plus pull-right"></i>
+                <span class="badge badge-default">{{parent.count}}</span> {{parent.name}}
+              </div>
+              <div id="collapse-{{parent.name|slugify}}" class="panel-collapse collapse">
+                <div class="panel-body">
+                  {% for child in parent.children %}
+                    <p class="no-pad-bottom">
+                      {% if child.count == 0 %}
+                        <span class="badge badge-default-light">{{child.count}}</span>
+                      {% else %}
+                        <span class="badge badge-default">{{child.count}}</span>
+                      {% endif %}
+                      <a href="/search/?q=&selected_facets=topics_exact:{{child.name}}">
+                        {{child.name}}
+                      </a>
+                    </p>
+                    <ul>
+                      {% for grandchild in child.children %}
+                        <li class="small">
+                          {% if grandchild.count == 0 %}
+                            <span class="badge badge-default-light">{{grandchild.count}}</span>
+                          {% else %}
+                            <span class="badge badge-default">{{grandchild.count}}</span>
+                          {% endif %}
+                          <a href="/search/?q=&selected_facets=topics_exact:{{grandchild.name}}">
+                            {{grandchild.name}}
+                          </a>
+                        </li>
+                      {% endfor %}
+                    </ul>
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+          </div>
+
+
+        {% endfor %}
+
+
+      </div>
+
+    </div>
+  </div>
+
+
+  {% if recent_bills %}
+    <div class="container-fluid" id="section-recent-activity">
+      <div class="row-fluid">
+        <div class='col-sm-10 col-sm-offset-1'>
+          <div class="divider"></div>
+          <h2>
+            <i class="fa fa-fw fa-clock-o"></i>Since the last council meeting
+          </h2>
+          <p>
+            After {{last_council_meeting.start_time | date:"M jS"}}, City Council introduced
+            <strong>{{recent_bills | length}}</strong> new pieces of legislation, including <strong>{{nonroutine_recent_bills | length}}</strong> that are
+            <a href="/search/?q=&selected_facets=topics_exact:Non-Routine">non-routine</a>.
+          </p>
+        </div>
+      </div>
+
+      {% if nonroutine_recent_bills %}
+        <div class="row-fluid">
+          <div class='col-sm-6 col-sm-offset-1'>
+            <h3>
+              Non-routine legislation introduced
+            </h3>
+            {% for legislation in nonroutine_recent_bills %}
+              <div class="bill-recent">
+                {% include "partials/legislation_item.html" %}
+              </div>
+            {% endfor %}
+            {% if nonroutine_recent_bills|length > 4%}
+              <a href="" id="more-bills-recent" class="btn btn-info"><i class="fa fa-fw fa-chevron-down"></i>Show more</a>
+              <a href="" id="fewer-bills-recent" class="btn btn-info"><i class="fa fa-fw fa-chevron-up"></i>Show fewer</a>
+            {% endif %}
+            <div class="divider"></div>
+          </div>
+
+        </div>
+      {% endif %}
+      <div class="divider"></div>
+    </div>
+  {% endif %}
+
 {% endblock %}
 
 

--- a/chicago/templates/person.html
+++ b/chicago/templates/person.html
@@ -1,6 +1,5 @@
 {% extends "base_with_margins.html" %}
 {% load static chicago_extras %}
-{% load adv_cache %}
 {% block title %}{{ person.name }}{% endblock %}
 
 {% block extra_css %}

--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -176,9 +176,9 @@ RQ_QUEUES = {
 }
 
 # Enforce SSL in production
-# if DEBUG is False:
-#     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-#     SECURE_SSL_REDIRECT = True
+if DEBUG is False:
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+    SECURE_SSL_REDIRECT = True
 
 # These are all the settings that are specific to a jurisdiction
 

--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -86,7 +86,6 @@ INSTALLED_APPS = (
     "notifications",
     "django_rq",
     "password_reset",
-    "adv_cache_tag",
 )
 
 try:
@@ -98,7 +97,9 @@ MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.cache.UpdateCacheMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "django.middleware.cache.FetchFromCacheMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -175,9 +176,9 @@ RQ_QUEUES = {
 }
 
 # Enforce SSL in production
-if DEBUG is False:
-    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-    SECURE_SSL_REDIRECT = True
+# if DEBUG is False:
+#     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+#     SECURE_SSL_REDIRECT = True
 
 # These are all the settings that are specific to a jurisdiction
 


### PR DESCRIPTION
We were using `adv_cache_tag` to wrap select blocks to be cached with a custom tag name and expire time. This led to lots of extra block tags and some pages with no caching at all. Now that we're not using notifications, we can just use the middleware caching for all pages instead. This PR makes that change.