### PR TITLE
chache and mobile improvements for divided votes

### DIFF
--- a/chicago/templates/base_with_margins.html
+++ b/chicago/templates/base_with_margins.html
@@ -1,10 +1,8 @@
 {% extends "base.html" %}
 {% block full_content %}
   <div class="container-fluid">
-    <div class='col-sm-12'>
-      {% block content %}
-      {% endblock %}
-    </div>
+    {% block content %}
+    {% endblock %}
   </div>
 
 {% endblock %}

--- a/chicago/templates/divided_votes.html
+++ b/chicago/templates/divided_votes.html
@@ -4,91 +4,84 @@
 
 {% block content %}
 
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col-sm-8">
-        <h1>Divided Votes - {{ legislative_session.name }}</h1>
+  <div class="row">
+    <div class="col-sm-8">
+      <h1>Divided Votes - {{ legislative_session.name }}</h1>
 
-        <p>For the {{ legislative_session.name }} of Chicago City Council under <strong>Mayor {{legislative_session.identifier|get_mayor}}</strong>, there have been <strong>{{bills|length}} votes</strong> with any dissenting "No" votes (sometimes referred to as a divided roll call). Everything else has either been held in committee with no vote or is considered noncontroversial and has passed unanimously.</p>
+      <p>For the {{ legislative_session.name }} of Chicago City Council under <strong>Mayor {{legislative_session.identifier|get_mayor}}</strong>, there have been <strong>{{bills|length}} votes</strong> with any dissenting "No" votes (sometimes referred to as a divided roll call). Everything else has either been held in committee with no vote or is considered noncontroversial and has passed unanimously.</p>
 
-        <p>Filter by legislative term:
-          {% for term in legislative_session_options %}
-            <a href="/divided-votes/{{term}}/" class="btn btn-primary {% if legislative_session.identifier == term %}active{% endif %}">{{term}}</a>
-          {% endfor %}
-        </p>
-      </div>
-      <div class="col-sm-12">
-        <div class="table-responsive">
-          <table class='table' id='split-votes'>
-            <thead>
+      <p>Filter by legislative term: <br class="visible-xs" />
+        {% for term in legislative_session_options %}
+          <a href="/divided-votes/{{term}}/" class="btn btn-primary {% if legislative_session.identifier == term %}active{% endif %}">{{term}}</a>
+        {% endfor %}
+      </p>
+    </div>
+    <div class="col-sm-12">
+      <div class="table-responsive">
+        <table class='table' id='split-votes'>
+          <thead>
+            <tr>
+              <th>Legislation</th>
+              <th>Primary sponsor</th>
+              <th>Date of last action</th>
+              <th>Votes for</th>
+              <th>Votes against</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for legislation in bills %}
               <tr>
-                <th>Legislation</th>
-                <th>Primary sponsor</th>
-                <th>Topics</th>
-                <th>Date of last action</th>
-                <th>Status</th>
-                <th>Votes for</th>
-                <th>Votes against</th>
+                <td>
+                  <p class='h4'><a href="{% url 'bill_detail' legislation.slug %}">{{ legislation.friendly_name }}</a> {{ legislation.inferred_status | inferred_status_label | safe }}</p>
+                  {{ legislation.listing_description | short_blurb }}
+
+                  {% if legislation.topics %}
+                    <br />
+                    <i class="fa fa-fw fa-tag"></i>
+                    {% for tag in legislation.topics %}
+                      <span class="badge badge-muted pseudo-topic-tag">
+                        <a href='/search/?q=&selected_facets=topics_exact:{{ tag }}'>{{ tag }}</a>
+                      </span>
+                    {% endfor %}
+                    <br/>
+                  {% else %}
+                    <i class="fa fa-fw fa-tag"></i>
+                    {% for tag in legislation.pseudo_topics %}
+                      <span class="badge badge-muted pseudo-topic-tag">
+                        <a href='/search/?q=&selected_facets=topics_exact:{{ tag | committee_topic_only}}'>{{ tag | committee_topic_only }}</a>
+                      </span>
+                    {% endfor %}
+                    <br/>
+                  {% endif %}
+                </td>
+                <td class="nowrap">
+                  {{legislation.primary_sponsor.person.name}}
+                </td>
+                <td>
+                  {% firstof legislation.last_action_date|date:'n/d/Y' legislation.get_last_action_date|date:'n/d/Y' %}
+                </td>
+                <td>
+                  {% for vote_event in legislation.votes.all %}
+                    {% for count in vote_event.counts.all %}
+                      {% if count.option == 'yes' %}
+                        {{count.value}}
+                      {% endif %}
+                    {% endfor %}
+                  {% endfor %}
+                </td>
+                <td>
+                  {% for vote_event in legislation.votes.all %}
+                    {% for count in vote_event.counts.all %}
+                      {% if count.option == 'no' %}
+                        {{count.value}}
+                      {% endif %}
+                    {% endfor %}
+                  {% endfor %}
+                </td>
               </tr>
-            </thead>
-            <tbody>
-              {% for legislation in bills %}
-                <tr>
-                  <td>
-                    <p class='h4'><a href="{% url 'bill_detail' legislation.slug %}">{{ legislation.friendly_name }}</a></p>
-                    {{ legislation.listing_description | short_blurb }}
-                  </td>
-                  <td class="nowrap">
-                    {{legislation.primary_sponsor.person.name}}
-                  </td>
-                  <td>
-                    {% if legislation.topics %}
-                      <i class="fa fa-fw fa-tag"></i>
-                      {% for tag in legislation.topics %}
-                        <span class="badge badge-muted pseudo-topic-tag">
-                          <a href='/search/?q=&selected_facets=topics_exact:{{ tag }}'>{{ tag }}</a>
-                        </span>
-                      {% endfor %}
-                      <br/>
-                    {% else %}
-                      <i class="fa fa-fw fa-tag"></i>
-                      {% for tag in legislation.pseudo_topics %}
-                        <span class="badge badge-muted pseudo-topic-tag">
-                          <a href='/search/?q=&selected_facets=topics_exact:{{ tag | committee_topic_only}}'>{{ tag | committee_topic_only }}</a>
-                        </span>
-                      {% endfor %}
-                      <br/>
-                    {% endif %}
-                  </td>
-                  <td>
-                    {% firstof legislation.last_action_date|date:'n/d/Y' legislation.get_last_action_date|date:'n/d/Y' %}
-                  </td>
-                  <td>
-                    {{ legislation.inferred_status | inferred_status_label | safe }}
-                  </td>
-                  <td>
-                    {% for vote_event in legislation.votes.all %}
-                      {% for count in vote_event.counts.all %}
-                        {% if count.option == 'yes' %}
-                          {{count.value}}
-                        {% endif %}
-                      {% endfor %}
-                    {% endfor %}
-                  </td>
-                  <td>
-                    {% for vote_event in legislation.votes.all %}
-                      {% for count in vote_event.counts.all %}
-                        {% if count.option == 'no' %}
-                          {{count.value}}
-                        {% endif %}
-                      {% endfor %}
-                    {% endfor %}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
     </div>
   </div>
@@ -106,10 +99,8 @@
       "searching": true,
       "bLengthChange": false,
       "paging": false,
-      "aaSorting": [ [3,'desc'] ],
+      "aaSorting": [ [2,'desc'] ],
       "aoColumns": [
-        null,
-        null,
         null,
         null,
         null,

--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -66,6 +66,7 @@ CACHES = {
     "default": {
         "BACKEND": f"django.core.cache.backends.{cache_backend}",
         "LOCATION": "site_cache",
+        "TIMEOUT": 21600,  # 6 hours
     }
 }
 


### PR DESCRIPTION
Divided votes has quite a few columns that aren't really useful to sort/filter on. This PR removes them.

Additionally I updated cache timeout to 6 hours (was 5 min by default) and removed some additional margins in the base page