### PR TITLE
cache site for 24 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Chicago Councilmatic is a free and easy way to access official Chicago City Coun
 
 ## Production data and SQLite archive
 
-If you'd like to explore the data for Chicago Councilmatic yourself, we make a SQLite database using Datasette](https://datasette.io/) available here: https://puddle.bunkum.us/chicago_council. This data is updated nightly.
+If you'd like to explore the data for Chicago Councilmatic yourself, we make a SQLite database using [Datasette](https://datasette.io/) available here: https://puddle.bunkum.us/chicago_council. This data is updated nightly.
 
 The data updates for the production instance of this site is done with GitHub actions in the https://github.com/datamade/chicago-council-scrapers repository. Data is also updated nightly.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # 👀 Chicago Councilmatic
 
-Keep track of what the Chicago City Council is doing.
+Chicago Councilmatic tracks all things related to Chicago City Council: the legislation introduced and passed, its various committees and the meetings they hold, and the aldermen themselves.
+
+You can search and browse legislation from 2011 onwards. Some interesting searches include:
+
+- changes in how properties are zoned
+- what the City is paying out in settlements
+- committee appointments
+- celebrating birthdays?!
+
+Chicago Councilmatic is a free and easy way to access official Chicago City Council information.
+
+## Production data and SQLite archive
+
+If you'd like to explore the data for Chicago Councilmatic yourself, we make a SQLite database using Datasette](https://datasette.io/) available here: https://puddle.bunkum.us/chicago_council. This data is updated nightly.
+
+The data updates for the production instance of this site is done with GitHub actions in the https://github.com/datamade/chicago-council-scrapers repository. Data is also updated nightly.
 
 ## Setup
 
@@ -115,10 +130,6 @@ breaks. To run them, add some data to your database, as described in
 ```bash
 docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
 ```
-
-## Production site data updates
-
-The data updates for the production instance of this site is done with GitHub actions in the https://github.com/datamade/chicago-council-scrapers repository.
 
 ## Team
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ breaks. To run them, add some data to your database, as described in
 docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
 ```
 
+## Production site data updates
+
+The data updates for the production instance of this site is done with GitHub actions in the https://github.com/datamade/chicago-council-scrapers repository.
+
 ## Team
 
 ### Original project team

--- a/chicago/templates/about.html
+++ b/chicago/templates/about.html
@@ -2,83 +2,85 @@
 {% block title %}About{% endblock %}
 {% block content %}
 
-  <div class="row-fluid clearfix">
-    <div class="col-sm-8 ">
-      <br />
-      <h1 id='about'>About</h1>
+  <div class="col-sm-12">
+    <div class="row clearfix">
+      <div class="col-sm-8 ">
+        <br />
+        <h1 id='about'>About</h1>
 
-      <p><strong>Chicago Councilmatic</strong> tracks all things related to Chicago City Council: the <a href='/search/'>legislation</a> introduced and passed, its various <a href='/committees/'>committees</a> and the <a href='/events/'>meetings</a> they hold, and the <a href='/council-members/'>aldermen</a> themselves.</p>
+        <p><strong>Chicago Councilmatic</strong> tracks all things related to Chicago City Council: the <a href='/search/'>legislation</a> introduced and passed, its various <a href='/committees/'>committees</a> and the <a href='/events/'>meetings</a> they hold, and the <a href='/council-members/'>aldermen</a> themselves.</p>
 
-      <p>You can search and browse legislation from 2011 onwards. Some interesting searches include:</p>
+        <p>You can search and browse legislation from 2011 onwards. Some interesting searches include:</p>
 
-      <ul>
-        <li><a href="/search/?q=&selected_facets=topics_exact:Zoning Reclassification" >changes in how properties are zoned</a></li>
-        <li><a href="/search/?q=settlement&selected_facets=bill_type_exact:Report" >what the City is paying out in settlements</a></li>
-        <li><a href="/search/?q=&selected_facets=topics_exact:Committe Appointments" >committee appointments</a></li>
-        <li><a href="/search/?q=birthday" >celebrating birthdays?!</a></li>
-      </ul>
-
-      <p>Chicago Councilmatic is a free and easy way to access official Chicago City Council information.</p>
-
-    </div>
-    <div class="col-sm-4 desktop-only">
-      <div class="well well-sm">
-        <h4>Contents</h4>
-        <ul class="less-pad-list">
-          <li>
-            <a href="/about">About</a>
-          </li>
-          <li>
-            <a href="#about-city-council">What is Chicago City Council,<br />and how does it work?</a>
-          </li>
-          <li>
-            <a href="#tags">Legislation tags</a>
-          </li>
-          <li>
-            <a href="#open-source">We're open source!</a>
-          </li>
-          <li>
-            <a href="#data">Data</a>
-          </li>
-          <li>
-            <a href="#team">Team</a>
-          </li>
-          <li>
-            <a href="#contact">Contact us</a>
-          </li>
-          <li>
-            <a href="#bring-councilmatic">Bring Councilmatic to your city!</a>
-          </li>
-          <li>
-            <a href="#credits">Credits</a>
-          </li>
+        <ul>
+          <li><a href="/search/?q=&selected_facets=topics_exact:Zoning Reclassification" >changes in how properties are zoned</a></li>
+          <li><a href="/search/?q=settlement&selected_facets=bill_type_exact:Report" >what the City is paying out in settlements</a></li>
+          <li><a href="/search/?q=&selected_facets=topics_exact:Committe Appointments" >committee appointments</a></li>
+          <li><a href="/search/?q=birthday" >celebrating birthdays?!</a></li>
         </ul>
+
+        <p>Chicago Councilmatic is a free and easy way to access official Chicago City Council information.</p>
+
+      </div>
+      <div class="col-sm-4 desktop-only">
+        <br /><br />
+        <div class="well well-sm">
+          <h4>Contents</h4>
+          <ul class="less-pad-list">
+            <li>
+              <a href="/about">About</a>
+            </li>
+            <li>
+              <a href="#about-city-council">What is Chicago City Council,<br />and how does it work?</a>
+            </li>
+            <li>
+              <a href="#tags">Legislation tags</a>
+            </li>
+            <li>
+              <a href="#open-source">We're open source!</a>
+            </li>
+            <li>
+              <a href="#data">Data</a>
+            </li>
+            <li>
+              <a href="#team">Team</a>
+            </li>
+            <li>
+              <a href="#contact">Contact us</a>
+            </li>
+            <li>
+              <a href="#bring-councilmatic">Bring Councilmatic to your city!</a>
+            </li>
+            <li>
+              <a href="#credits">Credits</a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="row-fluid">
-    <div class="col-sm-8" id="about-city-council">
-      <h3>What is Chicago City Council, and how does it work?</h3>
+    <div class="row-fluid">
+      <div class="col-sm-8" id="about-city-council">
+        <h3>What is Chicago City Council, and how does it work?</h3>
 
-      <p>Chicago City Council is the legislative body of the City of Chicago. It consists of <a href='/council-members' >50 elected aldermen</a>, each representing one of Chicago's wards. City Council meets monthly and is presided over by <a href='/person/lightfoot-lori-e-f6faf37c9643/' >Lori Lightfoot</a>, the Mayor of Chicago. The secretary is <a href='/person/valencia-anna-m-ae119fe8c2e3/' >Anna Valencia</a>, City Clerk of Chicago</a>.</p>
+        <p>Chicago City Council is the legislative body of the City of Chicago. It consists of <a href='/council-members' >50 elected aldermen</a>, each representing one of Chicago's wards. City Council meets monthly and is presided over by <a href='/person/lightfoot-lori-e-f6faf37c9643/' >Lori Lightfoot</a>, the Mayor of Chicago. The secretary is <a href='/person/valencia-anna-m-ae119fe8c2e3/' >Anna Valencia</a>, City Clerk of Chicago</a>.</p>
 
-    <p>Generally, Chicago City Council deals with the following topics:</p>
+      <p>Generally, Chicago City Council deals with the following topics:</p>
 
-    <ul>
-      <li><a href='/search/?&selected_facets=topics_exact:City%20Matters' >city-wide policies</a> - usually proposed by the mayor</li>
-      <li><a href='/search/?&selected_facets=topics_exact:Ward%20Matters' >local ward matters</a> - spearheaded by Aldermen</li>
-      <li><a href='/search/?&selected_facets=topics_exact:Residents' >matters involving individuals</a> - miscellaneous claims & honorifics</li>
-    </ul>
+      <ul>
+        <li><a href='/search/?&selected_facets=topics_exact:City%20Matters' >city-wide policies</a> - usually proposed by the mayor</li>
+        <li><a href='/search/?&selected_facets=topics_exact:Ward%20Matters' >local ward matters</a> - spearheaded by Aldermen</li>
+        <li><a href='/search/?&selected_facets=topics_exact:Residents' >matters involving individuals</a> - miscellaneous claims & honorifics</li>
+      </ul>
 
-    <p>For the nitty-gritty on how Chicago City Council works, read about its <a href='http://chicityclerk.com/city-council-news-central/council-agenda' target="_blank">structure</a> and <a href='http://www.chicityclerk.com/city-council-news-central/rules-order' target="_blank">rules</a> from the City Clerk.</p>
+      <p>For the nitty-gritty on how Chicago City Council works, read about its <a href='http://chicityclerk.com/city-council-news-central/council-agenda' target="_blank">structure</a> and <a href='http://www.chicityclerk.com/city-council-news-central/rules-order' target="_blank">rules</a> from the City Clerk.</p>
 
-    <br/>
-    <h4>Types of legislation</h4>
-    <p>Below are the categories of legislation in Chicago:</p>
+      <br/>
+      <h4>Types of legislation</h4>
+      <p>Below are the categories of legislation in Chicago:</p>
 
-    {% include 'partials/component_bill_type_table.html' %}
+      {% include 'partials/component_bill_type_table.html' %}
 
-  </div>
+    </div>
   </div>
 
 
@@ -103,14 +105,16 @@
     <div class="col-sm-8" id="data">
       <h3>Data</h3>
 
+      <p>If you'd like to explore the data for Chicago Councilmatic yourself, we make a SQLite database using <a href='https://datasette.io/'>Datasette</a> available here: <a href='https://puddle.bunkum.us/chicago_council'>https://puddle.bunkum.us/chicago_council</a>. This data is updated nightly.</p>
+
       <p>The data on this website comes from the <a href="http://chicago.legistar.com/" target="_blank">Chicago City Council legislation site</a>, a system built by <a href='http://www.granicus.com/' target="_blank">Granicus</a> using their <a href='https://www.granicus.com/solutions/meeting-agenda-suite/' target="_blank">Legistar Legislative Management Suite</a>. The <a href='http://chicityclerk.com/' target="_blank">Office of the City Clerk</a>manages the data, and on Councilmatic, each piece of legislation provides a link to its source for reference.</p>
 
       <p>Daily, DataMade collects data from Legistar and the <a href='http://webapi.legistar.com/' target="_blank">Legistar Web API</a>, which we store using the <a href="https://github.com/opencivicdata" target="_blank">Open Civic Data</a> standard and platform. Built in collaboration with <a href="http://sunlightfoundation.com/" target="_blank">The Sunlight Foundation</a>, <a href="https://developers.google.com/civic-information/?hl=en" target="_blank">Google</a>, <a href="http://www.granicus.com/" target="_blank">Granicus</a>, and <a href="http://www.opennorth.ca/" target="_blank">Open North</a>, Open Civic Data standardizes information about people, organizations, events, and bills at any level of government.</p>
 
-      <p><a href='http://opencivicdata.org' target="_blank"><img style='height:100px;' src='/static/images/ocd.jpg' /></a></p>
+      <p><a href='https://opencivicdata.info/en/latest/' target="_blank"><img style='height:100px;' src='/static/images/ocd.jpg' /></a></p>
 
       <br>
-      <a class='btn btn-primary' href='http://ocd-api-documentation.readthedocs.io/en/latest/index.html' target='_blank'>Read OCD API documentation<i class="fa fa-chevron-right" aria-hidden="true"></i></a>
+      <a class='btn btn-primary' href='https://opencivicdata.info/en/latest/' target='_blank'>Read the OCD documentation<i class="fa fa-chevron-right" aria-hidden="true"></i></a>
       <br>
     </div>
 
@@ -155,5 +159,5 @@
 
         </div>
       </div>
-
+    </div>
 {% endblock %}

--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -66,13 +66,13 @@ CACHES = {
     "default": {
         "BACKEND": f"django.core.cache.backends.{cache_backend}",
         "LOCATION": "site_cache",
-        "TIMEOUT": 21600,  # 6 hours
+        "TIMEOUT": 86400,  # 24 hours
     }
 }
 
 # settings for cache middleware
 CACHE_MIDDLEWARE_ALIAS = "default"
-CACHE_MIDDLEWARE_SECONDS = 21600  # 6 hours
+CACHE_MIDDLEWARE_SECONDS = (86400,)  # 24 hours
 CACHE_MIDDLEWARE_KEY_PREFIX = ""
 
 

--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -72,7 +72,7 @@ CACHES = {
 
 # settings for cache middleware
 CACHE_MIDDLEWARE_ALIAS = "default"
-CACHE_MIDDLEWARE_SECONDS = (86400,)  # 24 hours
+CACHE_MIDDLEWARE_SECONDS = 86400  # 24 hours
 CACHE_MIDDLEWARE_KEY_PREFIX = ""
 
 


### PR DESCRIPTION
This increases the cache timeout from 6 hours to 24 hours to improve performance.

Related to https://github.com/datamade/chicago-council-scrapers/pull/5, which should be brought in at the same time.

This PR also updates the README and about pages linking to the datasette download link and chicago-council-scrapers repo. Closes #332 