### PR TITLE
patch for missing person attributes

### DIFF
--- a/chicago/models.py
+++ b/chicago/models.py
@@ -253,10 +253,17 @@ class ChicagoPerson(Person):
 
     @property
     def term_active(self):
+        # older entries may not have a latest_council_membership
+        if self.latest_council_membership is None:
+            return False
+
         return self.latest_council_membership.end_date_dt > timezone.now()
 
     @property
     def years_in_office(self):
+        if self.latest_council_membership is None:
+            return ""
+
         years = 0
         if self.term_active:
             years = relativedelta(

--- a/chicago/templates/person.html
+++ b/chicago/templates/person.html
@@ -104,20 +104,24 @@
             </span>
           </a>
         </li>
-        <li role="presentation" {% if request.GET.view == 'committees' %}class='active' {% endif %}>    <a href="/person/{{person.slug}}/?view=committees">
-          <span class="small-pill">
-            <i class='fa fa-fw fa-group'></i>
-            Committees ({{committee_count}})
-          </span>
-        </a>
-        </li>
-        <li role="presentation" {% if request.GET.view == 'attendance' %}class='active' {% endif %}>    <a href="/person/{{person.slug}}/?view=attendance">
-          <span class="small-pill">
-            <i class='fa fa-fw fa-calendar-o'></i>
-            Attendance ({{person.attendance_percent}})
-          </span>
-        </a>
-        </li>
+        {% if committee_count > 0 %}
+          <li role="presentation" {% if request.GET.view == 'committees' %}class='active' {% endif %}>    <a href="/person/{{person.slug}}/?view=committees">
+            <span class="small-pill">
+              <i class='fa fa-fw fa-group'></i>
+              Committees ({{committee_count}})
+            </span>
+          </a>
+          </li>
+        {% endif %}
+        {% if person.attendance_percent != 0 %}
+          <li role="presentation" {% if request.GET.view == 'attendance' %}class='active' {% endif %}>    <a href="/person/{{person.slug}}/?view=attendance">
+            <span class="small-pill">
+              <i class='fa fa-fw fa-calendar-o'></i>
+              Attendance ({{person.attendance_percent}})
+            </span>
+          </a>
+          </li>
+        {% endif %}
       </ul>
 
       {% if request.GET.view == 'bills' or request.GET.view == None %}

--- a/chicago/templatetags/chicago_extras.py
+++ b/chicago/templatetags/chicago_extras.py
@@ -7,8 +7,9 @@ register = template.Library()
 @register.filter
 def get_person_headshot(person):
     for p in ALDER_EXTRAS:
-        if person.slug.startswith(p):
-            return f"/static/images/manual-headshots/{ALDER_EXTRAS[p]['image']}"
+        if person:
+            if person.slug.startswith(p):
+                return f"/static/images/manual-headshots/{ALDER_EXTRAS[p]['image']}"
 
     return "/static/images/headshot_placeholder.png"
 


### PR DESCRIPTION
Resolves two classes of errors we've been encountering:

- inactive people with no `latest_council_membership` (like Former Mayor Daley)

https://chicago.councilmatic.org/person/daley-richard-m-99518b1b825d/

- no `person` object for some inactive people 

https://chicago.councilmatic.org/legislation/o2015-3676/
https://chicago.councilmatic.org/legislation/r2014-358/
https://chicago.councilmatic.org/legislation/o2016-8592/

- also hides the committee and attendance tabs on the person page when these values are zero