### PR TITLE
removed data banner, removed substitute redirect view and url

### DIFF
--- a/chicago/templates/base.html
+++ b/chicago/templates/base.html
@@ -70,16 +70,6 @@
       </div>
     {% endif %}
 
-    <div class="container-fluid">
-      <div class="row">
-        <div class="col-sm-12">
-          <div class="alert alert-info" role="alert">
-            On June 16, 2023, the Chicago City Clerk replaced their legislative management system and we are working to update Councilmatic to get the latest data from it. In the meantime, please visit <a target='_blank' href='https://chicityclerkelms.chicago.gov/'>chicityclerkelms.chicago.gov</a> for the most up-to-date City Council activities.
-          </div>
-        </div>
-      </div>
-    </div>
-
     {% block full_content %}
     {% endblock %}
 

--- a/chicago/views.py
+++ b/chicago/views.py
@@ -8,7 +8,6 @@ from datetime import datetime
 import pytz
 from dateutil.relativedelta import relativedelta
 from urllib.parse import urlencode
-from django.shortcuts import redirect
 from django.conf import settings
 from django.http import Http404, HttpResponsePermanentRedirect
 from django.urls import reverse
@@ -289,10 +288,6 @@ class ChicagoBillDetailView(BillDetailView):
         if bill_classification in {"claim"} or bill_identifier == "Or 2013-382":
             context["seo"]["nofollow"] = True
         return context
-
-
-def substitute_ordinance_redirect(request, substitute_ordinance_slug):
-    return redirect("bill_detail", slug=substitute_ordinance_slug[1:], permanent=True)
 
 
 class ChicagoDividedVotesView(ListView):

--- a/councilmatic/urls.py
+++ b/councilmatic/urls.py
@@ -6,7 +6,6 @@ from chicago.views import (
     ChicagoCouncilmaticFacetedSearchView,
     ChicagoIndexView,
     ChicagoAboutView,
-    substitute_ordinance_redirect,
     ChicagoBillDetailView,
     ChicagoDividedVotesView,
     ChicagoPersonDetailView,
@@ -32,11 +31,6 @@ patterns = (
         url(r"^search/", ChicagoCouncilmaticFacetedSearchView.as_view(), name="search"),
         url(r"^$", ChicagoIndexView.as_view(), name="index"),
         url(r"^about/$", ChicagoAboutView.as_view(), name="about"),
-        url(
-            r"^legislation/(?P<substitute_ordinance_slug>s[^/]+)/*$",
-            substitute_ordinance_redirect,
-            name="substitute_ordinance_redirect",
-        ),
         url(
             r"^legislation/(?P<slug>[^/]+)/$",
             ChicagoBillDetailView.as_view(),


### PR DESCRIPTION
Substitute ordinances no longer need redirects in the new LMS. Removed the redirect logic.

We're also getting data from the new system, so removed the data banner.