### PR TITLE
add updates page with 3 recent entries

### DIFF
--- a/chicago/templates/base.html
+++ b/chicago/templates/base.html
@@ -34,7 +34,10 @@
             <a href="{% url 'about' %}">About</a>
           </li>
           <li>
-            <a href="{% url 'council_members' %}">{{ CITY_VOCAB.COUNCIL_MEMBERS }}</a>
+            <a href="/updates">Updates</a>
+          </li>
+          <li>
+            <a href="{% url 'council_members' %}">Find your Ward</a>
           </li>
           <li>
             <a href="/compare-council-members">Compare Alders</a>
@@ -77,7 +80,7 @@
       <div class='col-sm-12'>
         <div class='clearfix'></div>
 
-        <p>Part of the <a href='https://www.councilmatic.org' target="_blank">Councilmatic family</a>. Proudly brought to you by <a href="https://datamade.us">DataMade</a>. &copy; 2022</p>
+        <p>Part of the <a href='https://www.councilmatic.org' target="_blank">Councilmatic family</a>. Proudly brought to you by <a href="https://datamade.us">DataMade</a>. &copy; {% now "Y" %}</p>
 
       </div>
     </div>

--- a/chicago/templates/council_members.html
+++ b/chicago/templates/council_members.html
@@ -13,8 +13,8 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-sm-6">
-        <h1>{{ CITY_VOCAB.COUNCIL_MEMBERS }}</h1>
-        <h4>Look up your council member</h4>
+        <h1>Find your Ward and Alder</h1>
+        <h4>Enter your address or browse the map to find which Ward you live in</h4>
         <div class="input-group address-search">
           <input name="search_address" id='search_address' type="text" class="form-control" placeholder="Enter your address">
           <div class='input-group-btn'>

--- a/chicago/templates/updates.html
+++ b/chicago/templates/updates.html
@@ -1,0 +1,57 @@
+{% extends "base_with_margins.html" %}
+{% block title %}About{% endblock %}
+{% block content %}
+
+  <div class="col-sm-12">
+    <div class="row clearfix">
+      <div class="col-sm-8">
+        <br />
+        <h1 id='updates'>Updates</h1>
+
+        <p>Keep track of recent changes we have made to Chicago Councilmatic.</p>
+        <hr />
+
+        <h3>Aug 4, 2023: New legislation identifiers</h3>
+        <p>As part of the Chicago City Clerk's update to a new Legislative Management System, any legislation that was currently active in June 2023 was given a new identifier. These identifiers are different than the ones they were given in the Legistar system. For example, bill O2023-2091 in Legistar is now <a href='/legislation/o2023-0001686/'>O2023-0001686</a>.</p>
+
+        <p>To account for this, Councilmatic considers the new identifiers to be the canonical ones and we have set up redirects for legislation using the old identifier. To help avoid confusion, we also list out what the old identifier was at the top of each legislation page, if it has one.</p>
+
+        <br />
+        <h3>July 28, 2023: Using data from chicityclerkelms.chicago.gov</h3>
+
+        <p>We are now using data from <a href='https://chicityclerkelms.chicago.gov'>chicityclerkelms.chicago.gov</a> to power Chicago Councilmatic.</p>
+
+        <p>We have, however, noticed several issues with how the data in the new system is structured. We have informed the Chicago City Clerk about these issues.</p>
+
+        <p>The biggest issue is that in the action history of legislation, the actors are often missing and wrong for newer matters, at least based on how it was done under the Legistar system.</p>
+
+        <p>For example, O2023-1020, <a href='https://chicityclerkelms.chicago.gov/Matter/?matterId=6FBDB317-5C09-EE11-8F6D-001DD809B965'>https://chicityclerkelms.chicago.gov/Matter/?matterId=6FBDB317-5C09-EE11-8F6D-001DD809B965</a></p>
+
+        <ul>
+          <li>The actor is missing for the "introduce" and "failed to pass" actions.</li>
+          <li>The actor is wrong for the "refer" action. The actor should be City Council, not the Committee on Transportation and Public Way.</li>
+          <li>The actor is wrong for the "recommend do not pass" action, it should be the Committee on Transportation and Public Way, not City Council.</li>
+        </ul>
+
+        <p>This is pretty common with the recent legislation:</p>
+
+        <ul>
+          <li><a href='https://chicityclerkelms.chicago.gov/Matter/?matterId=359F7376-F509-EE11-8F6D-001DD809B965'>https://chicityclerkelms.chicago.gov/Matter/?matterId=359F7376-F509-EE11-8F6D-001DD809B965</a></li>
+          <li><a href='https://chicityclerkelms.chicago.gov/Matter/?matterId=90303FC2-000A-EE11-8F6D-001DD809B578'>https://chicityclerkelms.chicago.gov/Matter/?matterId=90303FC2-000A-EE11-8F6D-001DD809B578</a></li>
+          <li><a href='https://chicityclerkelms.chicago.gov/Matter/?matterId=A5F30658-E30A-EE11-8F6D-001DD809B965'>https://chicityclerkelms.chicago.gov/Matter/?matterId=A5F30658-E30A-EE11-8F6D-001DD809B965</a></li>
+        </ul>
+
+        <p>There are other challenges with the data. We are documenting the issues we run into in <a href='https://github.com/datamade/chi-councilmatic/issues/352'>this public GitHub issue</a>.</p>
+
+        <br />
+        <h3>June 16, 2023: Chicago City Clerk launches new system</h3>
+
+        <p>The Chicago City Clerk has launched a new Legislative Management System to replace Legistar. It can be reached at <a href='https://chicityclerkelms.chicago.gov'>chicityclerkelms.chicago.gov</a>.</p>
+
+        <p>While this system does have an API (<a href='https://api.chicityclerkelms.chicago.gov/'>api.chicityclerkelms.chicago.gov</a>), it will take us some time to update our scrapers to bring in data from this new source. Until then, data will not be updated on Chicago Councilmatic. You can keep track of the progress made on updating the scrapers at <a href='https://github.com/opencivicdata/scrapers-us-municipal/tree/chicago_comprehensive/chicago'>github.com/opencivicdata/scrapers-us-municipal/tree/chicago_comprehensive/chicago</a>.</p>
+
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/chicago/views.py
+++ b/chicago/views.py
@@ -117,6 +117,10 @@ class ChicagoAboutView(AboutView):
     template_name = "about.html"
 
 
+class ChicagoUpdatesView(AboutView):
+    template_name = "updates.html"
+
+
 class ChicagoCouncilmaticFacetedSearchView(FacetedSearchView):
 
     form_class = CouncilmaticSearchForm

--- a/councilmatic/urls.py
+++ b/councilmatic/urls.py
@@ -6,6 +6,7 @@ from chicago.views import (
     ChicagoCouncilmaticFacetedSearchView,
     ChicagoIndexView,
     ChicagoAboutView,
+    ChicagoUpdatesView,
     ChicagoBillDetailView,
     ChicagoDividedVotesView,
     ChicagoPersonDetailView,
@@ -31,6 +32,7 @@ patterns = (
         url(r"^search/", ChicagoCouncilmaticFacetedSearchView.as_view(), name="search"),
         url(r"^$", ChicagoIndexView.as_view(), name="index"),
         url(r"^about/$", ChicagoAboutView.as_view(), name="about"),
+        url(r"^updates/$", ChicagoUpdatesView.as_view(), name="updates"),
         url(
             r"^legislation/(?P<slug>[^/]+)/$",
             ChicagoBillDetailView.as_view(),


### PR DESCRIPTION
Adds new updates page to start logging changes we make to Chicago Councilmatic. I added 3 recent entries on switching to the new clerk LMS and addressing identifier redirects.

![Screen Shot 2023-08-09 at 4 37 02 PM](https://github.com/datamade/chi-councilmatic/assets/919583/5b88df03-bcdd-4238-891b-a90baea0ebcc)
