### PR TITLE
better event page: vimeo embed, event agenda

### DIFF
--- a/chicago/models.py
+++ b/chicago/models.py
@@ -7,12 +7,9 @@ from councilmatic_core.models import Bill, Event, Organization, Person
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db import models
-from django.db.models import Prefetch
 from django.utils import timezone
 from django.utils.functional import cached_property
-from opencivicdata.legislative.models import (BillSponsorship,
-                                              EventRelatedEntity,
-                                              LegislativeSession)
+from opencivicdata.legislative.models import LegislativeSession
 
 from .helpers import topic_classifier
 
@@ -180,7 +177,6 @@ class ChicagoEvent(Event):
         try:
             link = self.media.first().links.first().url
             vimeo_id = re.match(".*?([0-9]+)$", link).group(1)
-            print(link, vimeo_id)
             return vimeo_id
         except AttributeError:
             return None

--- a/chicago/models.py
+++ b/chicago/models.py
@@ -172,6 +172,30 @@ class ChicagoEvent(Event):
         else:
             return None
 
+    @property
+    def clean_agenda_items(self):
+        agenda_items = (
+            self.agenda.order_by("order").all().prefetch_related("related_entities")
+        )
+        agenda_deduped = []
+        descriptions_seen = []
+        for a in agenda_items:
+            if a.description not in descriptions_seen:
+                descriptions_seen.append(a.description)
+                agenda_deduped.append(a)
+
+        return agenda_deduped
+
+    @property
+    def video_vimeo_id(self):
+        try:
+            link = self.media.first().links.first().url
+            vimeo_id = re.match(".*?([0-9]+)$", link).group(1)
+            print(link, vimeo_id)
+            return vimeo_id
+        except AttributeError:
+            return None
+
 
 class ChicagoPerson(Person):
     class Meta:

--- a/chicago/models.py
+++ b/chicago/models.py
@@ -126,7 +126,7 @@ class ChicagoBill(Bill):
 
         return []
 
-    @property
+    @cached_property
     def full_text_doc_url(self):
         """
         override this if instead of having full text as string stored in
@@ -175,26 +175,7 @@ class ChicagoEvent(Event):
         else:
             return None
 
-    @property
-    def clean_agenda_items(self):
-
-        sponsors = BillSponsorship.objects.filter(entity_type="person").select_related(
-            "person__councilmatic_person"
-        )
-        related_bill = (
-            EventRelatedEntity.objects.filter(entity_type="bill")
-            .select_related("bill__councilmatic_bill")
-            .prefetch_related(
-                Prefetch("bill__sponsorships", queryset=sponsors, to_attr="sponsors")
-            )
-        )
-        agenda_items = self.agenda.order_by("order").prefetch_related(
-            Prefetch("related_entities", queryset=related_bill, to_attr="bills")
-        )
-
-        return agenda_items
-
-    @property
+    @cached_property
     def video_vimeo_id(self):
         try:
             link = self.media.first().links.first().url

--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -47,15 +47,15 @@
                 {% if agenda_item.description|lower != 'page break' %}
                   <td>{{ forloop.counter }}</td>
                   <td>{{agenda_item.description}}</td>
-                  {% if agenda_item.related_entities.first.bill %}
+                  {% if agenda_item.bills %}
                     <td>
-                      <a href="/legislation/{{agenda_item.related_entities.first.bill.councilmatic_bill.slug}}/">
-                        {{ agenda_item.related_entities.first.bill.councilmatic_bill.friendly_name }}
+                      <a href="/legislation/{{agenda_item.bills.0.bill.councilmatic_bill.slug}}/">
+                        {{ agenda_item.bills.0.bill.councilmatic_bill.friendly_name }}
                       </a>
                     </td>
                     <td>
-                      {% for s in agenda_item.related_entities.first.bill.councilmatic_bill.sponsorships.all %}
-                        {{ s.person.link_html | safe }}{% if not forloop.last %},{% endif %}
+                      {% for s in agenda_item.bills.0.bill.sponsors %}
+                        {{ s.person.councilmatic_person.link_html | safe }}{% if not forloop.last %},{% endif %}
                       {% endfor %}
                     </td>
                   {% else %}

--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -28,10 +28,10 @@
     <p><a href="https://vimeo.com/{{event.video_vimeo_id}}">View on Vimeo</a></p>
   {% endif %}
   <hr />
-  <div class="row-fluid">
-    <div class="col-sm-6">
+  <div class="row">
+    <div class="col-sm-10">
       {% if event.agenda.all %}
-        <h4>Agenda</h4>
+        <h4>Agenda: {{event.agenda.all|length}} items</h4>
         <table class="table table table-responsive">
           <thead>
             <tr>
@@ -55,7 +55,7 @@
                     </td>
                     <td>
                       {% for s in agenda_item.bills.0.bill.sponsors %}
-                        {{ s.person.councilmatic_person.link_html | safe }}{% if not forloop.last %},{% endif %}
+                        <span class="nowrap">{{ s.person.councilmatic_person.link_html | safe }}</span>{% if not forloop.last %},{% endif %}
                       {% endfor %}
                     </td>
                   {% else %}
@@ -69,24 +69,10 @@
         </table>
       {% endif %}
 
-      {% if event.documents.all %}
-        <h4>Attachments</h4>
-        <p>
-          {% for document in event.documents.all %}
-            <i class='fa fa-fw fa-file-text-o'></i> <a href="{{document.links.first.url}}">{{document.note}}</a><br />
-          {% endfor %}
-        </p>
-      {% endif %}
-      <div class="modal-links">
-        <!-- View on legistar -->
-        {{ event|get_legistar_link|safe }}
-      </div>
-    </div>
-    <div class="col-sm-6">
       <!-- only show attendance for past events that weren't cancelled -->
       {% if event.status == 'passed' %}
         {% if attendance_taken %}
-          <h4>Attendance: {{attendance_present}} Present, {{attendance_absent}} Absent</h4>
+          <h4>Alder Attendance: {{attendance_present}} Present, {{attendance_absent}} Absent</h4>
           <table class="table">
             <tr>
               <th></th>
@@ -110,10 +96,23 @@
             {% endfor %}
           </table>
         {% else %}
-          <h4>Attendance</h4>
+          <h4>Alder Attendance</h4>
           <p>Attendance was not taken for this meeting or has not been posted by the Clerk's office</p>
         {% endif %}
       {% endif %}
+
+      {% if event.documents.all %}
+        <h4>Attachments</h4>
+        <p>
+          {% for document in event.documents.all %}
+            <i class='fa fa-fw fa-file-text-o'></i> <a href="{{document.links.first.url}}">{{document.note}}</a><br />
+          {% endfor %}
+        </p>
+      {% endif %}
+      <div class="modal-links">
+        <!-- View on legistar -->
+        {{ event|get_legistar_link|safe }}
+      </div>
     </div>
   </div>
 

--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -23,28 +23,50 @@
     <i class="fa fa-fw fa-map-marker"></i> {{event.location}}
   </p>
 
+  {% if event.video_vimeo_id %}
+    <iframe src="https://player.vimeo.com/video/{{event.video_vimeo_id}}?h=b9331c0f77&title=0" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+    <p><a href="https://vimeo.com/{{event.video_vimeo_id}}">View on Vimeo</a></p>
+  {% endif %}
   <hr />
   <div class="row-fluid">
     <div class="col-sm-6">
       {% if event.clean_agenda_items %}
         <h4>Agenda</h4>
-        <p>
-          <ol>
+        <table class="table table table-responsive">
+          <thead>
+            <tr>
+              <th>Order</th>
+              <th>Description</th>
+              <th>ID</th>
+              <th>Sponsor(s)</th>
+            </tr>
+          </thead>
+          <tbody>
             {% for agenda_item in event.clean_agenda_items %}
-              {% if agenda_item.description|lower != 'page break' %}
-                <li>
-                  {% if agenda_item.related_bills.all %}
-                    <a href="/legislation/{{agenda_item.related_bills.first.bill.slug}}/">
-                      {{agenda_item.related_bills.first.bill.friendly_name}}
-                    </a>
-                    <br/>
+              <tr>
+                {% if agenda_item.description|lower != 'page break' %}
+                  <td>{{ forloop.counter }}</td>
+                  <td>{{agenda_item.description}}</td>
+                  {% if agenda_item.related_entities.first.bill.councilmatic_bill %}
+                    <td>
+                      <a href="/legislation/{{agenda_item.related_entities.first.bill.councilmatic_bill.slug}}/">
+                        {{ agenda_item.related_entities.first.bill.councilmatic_bill.friendly_name }}
+                      </a>
+                    </td>
+                    <td>
+                      {% for s in agenda_item.related_entities.first.bill.councilmatic_bill.sponsorships.all %}
+                        {{ s.person.link_html | safe }}{% if not forloop.last %},{% endif %}
+                      {% endfor %}
+                    </td>
+                  {% else %}
+                    <td></td>
+                    <td></td>
                   {% endif %}
-                  {{agenda_item.description}}
-                </li>
-              {% endif %}
+                {% endif %}
+              </tr>
             {% endfor %}
-          </ol>
-        </p>
+          </tbody>
+        </table>
       {% endif %}
 
       {% if event.documents.all %}

--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -30,7 +30,7 @@
   <hr />
   <div class="row-fluid">
     <div class="col-sm-6">
-      {% if event.clean_agenda_items %}
+      {% if event.agenda.all %}
         <h4>Agenda</h4>
         <table class="table table table-responsive">
           <thead>
@@ -42,7 +42,7 @@
             </tr>
           </thead>
           <tbody>
-            {% for agenda_item in event.clean_agenda_items %}
+            {% for agenda_item in event.agenda.all %}
               <tr>
                 {% if agenda_item.description|lower != 'page break' %}
                   <td>{{ forloop.counter }}</td>

--- a/chicago/templates/event.html
+++ b/chicago/templates/event.html
@@ -47,7 +47,7 @@
                 {% if agenda_item.description|lower != 'page break' %}
                   <td>{{ forloop.counter }}</td>
                   <td>{{agenda_item.description}}</td>
-                  {% if agenda_item.related_entities.first.bill.councilmatic_bill %}
+                  {% if agenda_item.related_entities.first.bill %}
                     <td>
                       <a href="/legislation/{{agenda_item.related_entities.first.bill.councilmatic_bill.slug}}/">
                         {{ agenda_item.related_entities.first.bill.councilmatic_bill.friendly_name }}

--- a/chicago/templates/legislation.html
+++ b/chicago/templates/legislation.html
@@ -30,19 +30,22 @@
       <br/>
       <p>{{ legislation.title }}</p>
 
-      {% if legislation.other_identifiers.all %}
+      {% with other_identifiers=legislation.other_identifiers.all %}
+      {% if other_identifiers %}
         <p>
           Alternate identifiers:
-          {% for identifier in legislation.other_identifiers.all %}
+          {% for identifier in other_identifiers %}
             {{ identifier.identifier }}
             {% if not forloop.last %} , {% endif %}
           {% endfor %}
         </p>
       {% endif %}
+      {% endwith %}
 
       <div class="divider"></div>
 
-      {% if legislation.sponsors %}
+      {% with sponsors=sponsors_qs.all %}
+      {% if sponsors %}
         <h3 class="no-pad-bottom"><i class='fa fa-fw fa-users'></i> Sponsors</h3>
 
         <div class="table-responsive">
@@ -51,8 +54,8 @@
               <tr>
                 <th></th>
                 <th>
-                  {% if legislation.sponsors.all|length > 1 %}
-                    Sponsors ({{legislation.sponsors.all|length}})
+                  {% if sponsors|length > 1 %}
+                    Sponsors ({{sponsors|length}})
                   {% else %}
                     Sponsor
                   {% endif %}
@@ -63,7 +66,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for s in legislation.sponsors %}
+              {% for s in sponsors %}
                 {% if s.primary %}
                   <tr>
                     <td>
@@ -80,7 +83,7 @@
                   </tr>
                 {% endif %}
               {% endfor %}
-              {% for s in legislation.sponsors %}
+              {% for s in sponsors %}
                 {% if not s.primary %}
                   <tr>
                     <td>
@@ -102,6 +105,7 @@
         </div>
         <div class="divider"></div>
       {% endif %}
+      {% endwith %}
 
       {% if legislation.actions %}
         <h3 class="no-pad-bottom"><i class='fa fa-fw fa-list-ul'></i> History</h3>

--- a/chicago/templates/legislation.html
+++ b/chicago/templates/legislation.html
@@ -30,7 +30,7 @@
       <br/>
       <p>{{ legislation.title }}</p>
 
-      {% if legislation.other_identifiers %}
+      {% if legislation.other_identifiers.all %}
         <p>
           Alternate identifiers:
           {% for identifier in legislation.other_identifiers.all %}
@@ -42,7 +42,7 @@
 
       <div class="divider"></div>
 
-      {% if legislation.sponsorships.all %}
+      {% if legislation.sponsors %}
         <h3 class="no-pad-bottom"><i class='fa fa-fw fa-users'></i> Sponsors</h3>
 
         <div class="table-responsive">
@@ -51,8 +51,8 @@
               <tr>
                 <th></th>
                 <th>
-                  {% if legislation.sponsorships.all|length > 1 %}
-                    Sponsors ({{legislation.sponsorships.all|length}})
+                  {% if legislation.sponsors.all|length > 1 %}
+                    Sponsors ({{legislation.sponsors.all|length}})
                   {% else %}
                     Sponsor
                   {% endif %}
@@ -63,36 +63,36 @@
               </tr>
             </thead>
             <tbody>
-              {% for s in legislation.sponsorships.all %}
-                {% if s.is_primary %}
+              {% for s in legislation.sponsors %}
+                {% if s.primary %}
                   <tr>
                     <td>
                       <div class="thumbnail-square">
-                        <img src='{{s.person|get_person_headshot}}' alt='{{s.person.name}}' title='{{s.person.name}}' class='img-responsive' />
+                        <img src='{{s.person.councilmatic_person|get_person_headshot}}' alt='{{s.person.name}}' title='{{s.person.name}}' class='img-responsive' />
                       </div>
                     </td>
                     <td>
-                      {{ s.person.link_html | safe }} <span class="badge badge-default">Primary Sponsor</span>
+		      <a href="{% url 'person' s.person.councilmatic_person.slug %}">{{ s.person.name }}</a><span class="badge badge-default">Primary Sponsor</span>
                     </td>
                     <td>
-                      {{s.person.latest_council_membership.post.label}}
+                      {{s.person.council_posts.0.post.label}}
                     </td>
                   </tr>
                 {% endif %}
               {% endfor %}
-              {% for s in legislation.sponsorships.all %}
-                {% if not s.is_primary %}
+              {% for s in legislation.sponsors %}
+                {% if not s.primary %}
                   <tr>
                     <td>
                       <div class="thumbnail-square">
-                        <img src='{{s.person|get_person_headshot}}' alt='{{s.person.name}}' title='{{s.person.name}}' class='img-responsive' />
+                        <img src='{{s.person.councilmatic_person|get_person_headshot}}' alt='{{s.person.name}}' title='{{s.person.name}}' class='img-responsive' />
                       </div>
                     </td>
                     <td>
-                      {{ s.person.link_html | safe }}
+                      <a href="{% url 'person' s.person.councilmatic_person.slug %}">{{ s.person.name }}</a>
                     </td>
                     <td>
-                      {{s.person.latest_council_membership.post.label}}
+                      {{s.person.council_posts.0.post.label}}
                     </td>
                   </tr>
                 {% endif %}
@@ -103,7 +103,7 @@
         <div class="divider"></div>
       {% endif %}
 
-      {% if actions %}
+      {% if legislation.actions %}
         <h3 class="no-pad-bottom"><i class='fa fa-fw fa-list-ul'></i> History</h3>
         <div class="table-responsive">
           <table class='table table-responsive' id='committee-actions'>
@@ -115,7 +115,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for action in actions %}
+              {% for action in legislation.actions.all %}
                 <tr>
                   <td class='nowrap text-muted'>
                     <span datetime='{{action.date }}'>{{action.date}}</span>
@@ -215,7 +215,7 @@
 
         {% for event in legislation.unique_related_upcoming_events %}
           <p>
-            {{event.start_time | date:'M d, Y' }} - {{event.link_html | safe}}
+            {{event.start_time | date:'M d, Y' }} - <a href="{% url event_detail event.slug %}" title="View Event Details">{{ event.name }}</a>
           </p>
         {% endfor %}
 
@@ -278,7 +278,7 @@
       "sourceOrganization": "{{ CITY_COUNCIL_NAME }}",
       "name": "{{ legislation.friendly_name }}",
       "alternateName": ["{{ legislation.identifier }}", "{{ legislation.identifier.split|join:'' }}"],
-      {% if actions %}"datePublished": "{{actions.0.date|date:'Y-m-d'}}", {% endif %}
+      {% if legislation.actions %}"datePublished": "{{legislation.actions.0.date|date:'Y-m-d'}}", {% endif %}
       "description": "{{ legislation.description }}",
       "text": "{% firstof legislation.full_text legislation.ocr_full_text %}"
     }

--- a/chicago/templates/partials/seo.html
+++ b/chicago/templates/partials/seo.html
@@ -8,7 +8,7 @@
   <meta name="description" content="{{seo.site_desc}}">
   <meta name="author" content="{{seo.site_author}}">
 
-  {% if seo.nofollow %}
+  {% if seo.noindex %}
     <meta name="robots" content="noindex">
   {% endif %}
 


### PR DESCRIPTION
For events with Vimeo links, shows that as an embed at the top:

![Screen Shot 2023-09-01 at 4 28 35 PM](https://github.com/datamade/chi-councilmatic/assets/919583/eddf421e-8633-475e-9342-34bcb5be59f7)

Formats the agenda as a table with links to ordinances and sponsors:

![Screen Shot 2023-09-01 at 4 31 21 PM](https://github.com/datamade/chi-councilmatic/assets/919583/bf108f91-4241-405c-9476-eef0a82d68bd)
