### PR TITLE
dynamic, paginated sitemap

### DIFF
--- a/chicago/templates/robots.txt
+++ b/chicago/templates/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/chicago/templates/robots.txt
+++ b/chicago/templates/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Allow: /
+Sitemap: https://chicago.councilmatic.org/sitemap.xml

--- a/chicago/views.py
+++ b/chicago/views.py
@@ -19,10 +19,12 @@ from dateutil import parser
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db.models import Max, Min, Prefetch, Subquery
+from django.core.paginator import Paginator
 from django.http import Http404, HttpResponsePermanentRedirect
 from django.urls import reverse
 from django.utils import timezone
 from django.views.generic import DetailView, ListView
+from django.contrib.sitemaps import Sitemap
 from haystack.generic_views import FacetedSearchView
 from opencivicdata.core.models import Membership
 from opencivicdata.legislative.models import (
@@ -628,3 +630,62 @@ class ChicagoEventDetailView(DetailView):
             .prefetch_related(Prefetch("agenda", queryset=agenda_items_qs))
             .prefetch_related("documents")
         )
+
+
+# sitemap definitions
+
+
+class ChicagoEventSitemap(Sitemap):
+    changefreq = "weekly"
+    priority = 0.5
+
+    def items(self):
+        return ChicagoEvent.objects.all()
+
+    def lastmod(self, obj):
+        return obj.start_time
+
+    def location(self, obj):
+        return f"/events/{obj.slug}"
+
+
+class ChicagoCommitteeSitemap(Sitemap):
+    changefreq = "yearly"
+    priority = 0.5
+
+    def items(self):
+        return Organization.committees().distinct("name")
+
+    def location(self, obj):
+        return f"/committee/{obj.slug}"
+
+
+class ChicagoPersonSitemap(Sitemap):
+    changefreq = "yearly"
+    priority = 0.5
+
+    def items(self):
+        return (
+            ChicagoPerson.objects.filter(
+                memberships__organization__name=settings.OCD_CITY_COUNCIL_NAME
+            )
+            .filter(memberships__end_date__gt=datetime.now())
+            .distinct()
+        )
+
+    def location(self, obj):
+        return f"/person/{obj.slug}"
+
+
+class ChicagoBillSitemap(Sitemap):
+    changefreq = "daily"
+    priority = 1
+
+    def items(self):
+        return ChicagoBill.objects.all()
+
+    def paginator(self):
+        return Paginator(self.items(self), 1000)
+
+    def location(self, obj):
+        return f"/legislation/{obj.slug}"

--- a/chicago/views_sitemaps.py
+++ b/chicago/views_sitemaps.py
@@ -1,0 +1,78 @@
+from django.urls import reverse
+from datetime import datetime
+from django.conf import settings
+from django.contrib.sitemaps import Sitemap
+
+from councilmatic_core.models import Organization
+from chicago.models import ChicagoBill, ChicagoEvent, ChicagoPerson
+
+
+class ChicagoEventSitemap(Sitemap):
+    changefreq = "weekly"
+    priority = 0.5
+
+    def items(self):
+        return ChicagoEvent.objects.all()
+
+    def lastmod(self, obj):
+        return obj.updated_at
+
+    def location(self, obj):
+        return reverse("event_detail", args=[obj.slug])
+
+
+class ChicagoCommitteeSitemap(Sitemap):
+    changefreq = "yearly"
+    priority = 0.5
+
+    def items(self):
+        return Organization.committees()
+
+    def lastmod(self, obj):
+        return obj.updated_at
+
+    def location(self, obj):
+        return reverse("committee_detail", args=[obj.slug])
+
+
+class ChicagoPersonSitemap(Sitemap):
+    changefreq = "yearly"
+    priority = 0.5
+
+    def items(self):
+        return (
+            ChicagoPerson.objects.filter(
+                memberships__organization__name=settings.OCD_CITY_COUNCIL_NAME
+            )
+            .filter(memberships__end_date__gt=datetime.now())
+            .distinct()
+        )
+
+    def location(self, obj):
+        return reverse("person", args=[obj.slug])
+
+
+class ChicagoBillSitemap(Sitemap):
+    changefreq = "daily"
+    priority = 1
+    limit = 10000
+
+    def items(self):
+        return ChicagoBill.objects.all()
+
+    def lastmod(self, obj):
+        return obj.updated_at
+
+    def location(self, obj):
+        return reverse("bill_detail", args=[obj.slug])
+
+
+class StaticViewSitemap(Sitemap):
+    priority = 0.5
+    changefreq = "weekly"
+
+    def items(self):
+        return ["index", "about", "council_members", "chicago:compare_council_members"]
+
+    def location(self, item):
+        return reverse(item)

--- a/councilmatic/settings.py
+++ b/councilmatic/settings.py
@@ -84,6 +84,7 @@ INSTALLED_APPS = (
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
+    "django.contrib.sitemaps",
     "haystack",
     "chicago",
     "councilmatic_core",

--- a/councilmatic/urls.py
+++ b/councilmatic/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import include, url
+from django.urls import path
 from django.contrib import admin
-from django.views.generic.base import RedirectView
+from django.views.generic.base import RedirectView, TemplateView
+from django.contrib.sitemaps.views import views
 
 from chicago.views import (
     ChicagoCouncilmaticFacetedSearchView,
@@ -15,11 +17,22 @@ from chicago.views import (
     ChicagoCouncilMembersCompareView,
     ChicagoCommitteeDetailView,
     ChicagoCommitteesView,
+    ChicagoEventSitemap,
+    ChicagoCommitteeSitemap,
+    ChicagoPersonSitemap,
+    ChicagoBillSitemap,
 )
 from chicago.feeds import (
     ChicagoBillDetailActionFeed,
     ChicagoCouncilmaticFacetedSearchFeed,
 )
+
+sitemaps = {
+    "meetings": ChicagoEventSitemap,
+    "committees": ChicagoCommitteeSitemap,
+    "people": ChicagoPersonSitemap,
+    "legislation": ChicagoBillSitemap,
+}
 
 patterns = (
     [
@@ -79,6 +92,22 @@ patterns = (
             name="committee_detail",
         ),
         url(r"^committees/$", ChicagoCommitteesView.as_view(), name="committees"),
+        path(
+            "robots.txt",
+            TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
+        ),
+        path(
+            "sitemap.xml",
+            views.index,
+            {"sitemaps": sitemaps},
+            name="django.contrib.sitemaps.views.index",
+        ),
+        path(
+            "sitemap-<section>.xml",
+            views.sitemap,
+            {"sitemaps": sitemaps},
+            name="django.contrib.sitemaps.views.sitemap",
+        ),
     ],
     "chicago",
 )

--- a/councilmatic/urls.py
+++ b/councilmatic/urls.py
@@ -2,7 +2,8 @@ from django.conf.urls import include, url
 from django.urls import path
 from django.contrib import admin
 from django.views.generic.base import RedirectView, TemplateView
-from django.contrib.sitemaps.views import views
+from django.contrib.sitemaps import views as sitemap_views
+from django.views.decorators.cache import cache_page
 
 from chicago.views import (
     ChicagoCouncilmaticFacetedSearchView,
@@ -17,21 +18,26 @@ from chicago.views import (
     ChicagoCouncilMembersCompareView,
     ChicagoCommitteeDetailView,
     ChicagoCommitteesView,
-    ChicagoEventSitemap,
-    ChicagoCommitteeSitemap,
-    ChicagoPersonSitemap,
-    ChicagoBillSitemap,
 )
 from chicago.feeds import (
     ChicagoBillDetailActionFeed,
     ChicagoCouncilmaticFacetedSearchFeed,
 )
+from chicago.views_sitemaps import (
+    ChicagoEventSitemap,
+    ChicagoCommitteeSitemap,
+    ChicagoPersonSitemap,
+    ChicagoBillSitemap,
+    StaticViewSitemap,
+)
 
+# to do: add static pages
 sitemaps = {
     "meetings": ChicagoEventSitemap,
     "committees": ChicagoCommitteeSitemap,
     "people": ChicagoPersonSitemap,
     "legislation": ChicagoBillSitemap,
+    "static": StaticViewSitemap,
 }
 
 patterns = (
@@ -98,15 +104,14 @@ patterns = (
         ),
         path(
             "sitemap.xml",
-            views.index,
-            {"sitemaps": sitemaps},
-            name="django.contrib.sitemaps.views.index",
+            cache_page(86400)(sitemap_views.index),
+            {"sitemaps": sitemaps, "sitemap_url_name": "chicago:sitemaps"},
         ),
         path(
-            "sitemap-<section>.xml",
-            views.sitemap,
+            "sitemap-<str:section>.xml",
+            cache_page(86400)(sitemap_views.sitemap),
             {"sitemaps": sitemaps},
-            name="django.contrib.sitemaps.views.sitemap",
+            name="sitemaps",
         ),
     ],
     "chicago",

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Allow: /


### PR DESCRIPTION
Django has a pretty robust sitemap framework that supports multiple sections and pagination. This is necessary for indexing our bills, of which we have over 150,000 of. https://docs.djangoproject.com/en/3.2/ref/contrib/sitemaps/

* adds a cached `sitemaps.xml` with an index of sitemaps, including paginated sitemap for legislation. closes #384 
* adds robots.txt
