### PR TITLE
search RSS fix

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+exclude =
+  venv,
+  **/migrations/*
+# So flake8 plays nicely with black
+# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
+max-line-length = 88
+extend-ignore = E203

--- a/chicago/feeds.py
+++ b/chicago/feeds.py
@@ -70,11 +70,8 @@ class FacetedSearchFeed(Feed):
         return title
 
     def link(self, obj):
-        # return the main non-RSS search URL somehow
-        # XXX maybe "quargs" - evz
-        # return reverse('councilmatic_search', args=(searchqueryset=self.sqs,))
         url = self.url_with_querystring(
-            reverse("{}:councilmatic_search_feed".format(settings.APP_NAME)),
+            reverse("search"),
             q=self.query,
         )
         return url

--- a/chicago/urls.py
+++ b/chicago/urls.py
@@ -25,7 +25,7 @@ sitemaps = {
 }
 
 patterns = [
-    url(r"^search/", views.FacetedSearchView.as_view(), name="search"),
+    url(r"^search/$", views.FacetedSearchView.as_view(), name="search"),
     url(r"^$", views.IndexView.as_view(), name="index"),
     url(r"^about/$", views.AboutView.as_view(), name="about"),
     url(
@@ -92,7 +92,7 @@ patterns = [
 
 feed_patterns = [
     url(
-        r"^search/rss/",
+        r"^search/rss/$",
         feeds.FacetedSearchFeed(),
         name="councilmatic_search_feed",
     ),

--- a/chicago/views.py
+++ b/chicago/views.py
@@ -189,8 +189,6 @@ class FacetedSearchView(FacetedSearchView):
                 except KeyError:
                     selected_facets[k] = [v]
 
-        print(selected_facets)
-
         return selected_facets
 
     def _get_query_parameters(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = chicago.settings

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE = chicago.settings

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,2 @@
 [tool:pytest]
-DJANGO_SETTINGS_MODULE = chicago.settings
-
-[flake8]
-exclude =
-  venv,
-  **/migrations/*
-# So flake8 plays nicely with black
-# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
-max-line-length = 88
-extend-ignore = E203
+DJANGO_SETTINGS_MODULE = tests.test_config

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [tool:pytest]
-DJANGO_SETTINGS_MODULE = tests.test_config
+DJANGO_SETTINGS_MODULE = chicago.settings


### PR DESCRIPTION
Updates `urls.py` to properly route to search rss.

Reverts `flake8` config settings

Closes #397 