### PR TITLE
list additional document attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Chicago Councilmatic is a free and easy way to access official Chicago City Coun
 
 ## Production data and SQLite archive
 
-If you'd like to explore the data for Chicago Councilmatic yourself, we make a SQLite database using [Datasette](https://datasette.io/) available here: https://puddle.bunkum.us/chicago_council. This data is updated nightly.
+If you'd like to explore the data for Chicago Councilmatic yourself, we make a SQLite database using [Datasette](https://datasette.io/) available here: https://puddle.datamade.us/chicago_council. This data is updated nightly.
 
 The data updates for the production instance of this site is done with GitHub actions in the https://github.com/datamade/chicago-council-scrapers repository. Data is also updated nightly.
 

--- a/chicago/models.py
+++ b/chicago/models.py
@@ -120,7 +120,7 @@ class ChicagoBill(Bill):
         """
         if self.versions.all():
             most_recent = self.versions.first().links.first().url
-            return f"https://corsproxy.bunkum.us/corsproxy/?apiurl={most_recent}"
+            return most_recent
         else:
             return None
 

--- a/chicago/templates/about.html
+++ b/chicago/templates/about.html
@@ -107,7 +107,7 @@
     <div class="col-sm-8" id="data">
       <h3>Data</h3>
 
-      <p>If you'd like to explore the data for Chicago Councilmatic yourself, we make a SQLite database using <a href='https://datasette.io/'>Datasette</a> available here: <a href='https://puddle.bunkum.us/chicago_council'>https://puddle.bunkum.us/chicago_council</a>. This data is updated nightly.</p>
+      <p>If you'd like to explore the data for Chicago Councilmatic yourself, we make a SQLite database using <a href='https://datasette.io/'>Datasette</a> available here: <a href='https://puddle.datamade.us/chicago_council'>https://puddle.datamade.us/chicago_council</a>. This data is updated nightly.</p>
 
       <p>The data on Councilmatic comes from the Chicago City Clerk <a href="https://chicityclerkelms.chicago.gov/" target="_blank">eLMS</a>, a custom legislation management system built by <a href="https://www.eki-digital.com/" target="_blank">EKI Digital</a> that was launched in June 2023. Prior to that, the City Clerk housed their data in the <a href='https://www.granicus.com/solutions/meeting-agenda-suite/' target="_blank">Legistar Legislative Management Suite</a> built by <a href='http://www.granicus.com/' target="_blank">Granicus</a>. The data on Councilmatic is sourced from both of these systems.</p>
 

--- a/chicago/templates/legislation.html
+++ b/chicago/templates/legislation.html
@@ -237,22 +237,18 @@
         <div class="divider"></div>
       {% endif %}
 
-      {% if legislation.attachments %}
-        <h3>
-          <i class='fa fa-fw fa-paperclip'></i>
-          Attachments ({{ legislation.attachments | length }})
-        </h3>
+      {% include 'partials/legislation_text.html' %}
+
+      {% if legislation.documents.all %}
+        <h3>Additional Documents</h3>
         <ul>
-          {% for doc in legislation.attachments %}
+          {% for document in legislation.documents.all|dictsort:"note" %}
             <li>
-              <a href="{{doc.url}}" target="blank">{{ doc.note }}</a>
+              <a href="{{document.links.first.url|proxy_url}}">{{ document.note }}</a>
             </li>
           {% endfor %}
         </ul>
-        <div class="divider"></div>
       {% endif %}
-
-      {% include 'partials/legislation_text.html' %}
 
       <h3>Tools</h3>
       <div class="modal-links">
@@ -308,7 +304,7 @@
     });
 
     if (window.screen.width > 768){
-      $("#pdf-embed").attr("src", "/pdfviewer/?file={{legislation.full_text_doc_url|urlencode}}");
+      $("#pdf-embed").attr("src", "/pdfviewer/?file={{legislation.full_text_doc_url|proxy_url|urlencode}}");
     }
     else{
       $('#pdf-embed').hide()

--- a/chicago/templates/partials/legislation_text.html
+++ b/chicago/templates/partials/legislation_text.html
@@ -6,7 +6,7 @@
     Legislation text
   </h3>
   <p>
-    <a id="pdf-download-link" target='_blank' href='{{legislation.full_text_doc_url}}'><i class='fa fa-fw fa-download'></i> Download PDF</a>
+    <a id="pdf-download-link" target='_blank' href='{{legislation.full_text_doc_url|proxy_url}}'><i class='fa fa-fw fa-download'></i> Download PDF</a>
   </p>
   <iframe
     id="pdf-embed"
@@ -22,7 +22,7 @@
   {% if legislation.ocr_full_text|clean_html|length > 65 %}
     <h3>
       <i class='fa fa-fw fa-file-text-o'></i>
-      Legislation text
+      Legislation Text
     </h3>
     <div class='panel panel-default'>
       <div class='panel-body'>

--- a/chicago/templatetags/extras.py
+++ b/chicago/templatetags/extras.py
@@ -198,3 +198,8 @@ def get_mayor(year):
         return "Richard M. Daley"
     else:
         return ""
+
+
+@register.filter
+def proxy_url(url):
+    return f"https://corsproxy.bunkum.us/corsproxy/?apiurl={url}"


### PR DESCRIPTION

* listing legislative documents in addition to the ordinance, when present, closes #413 
* adds a `proxy_url` template tag
* unrelated, also updates the puddle link to the datamade.us domain.

Example: o2024-0007772

<img width="734" alt="Screenshot 2024-03-29 at 12 20 19 PM" src="https://github.com/datamade/chi-councilmatic/assets/919583/7e8bde47-e3fe-4122-939a-0fdf683dafcc">
