### PR TITLE
get_legistar_link: rewrite stale chicago.legistar.com URLs to eLMS

### DIFF
--- a/chicago/templatetags/extras.py
+++ b/chicago/templatetags/extras.py
@@ -166,7 +166,19 @@ def get_person_headshot(person):
 def get_legistar_link(object):
     try:
         source = object.sources.get(note="web")
-        return f"<a href='{source.url}' target='_blank' rel='nofollow'><i class='fa fa-fw fa-link'></i> View on the {settings.CITY_VOCAB['SOURCE']} website</a>"  # noqa
+        url = source.url
+        # Bills scraped from the old chicago.legistar.com point at a host
+        # that's been replaced by the eLMS Matter page. Rewrite when we
+        # can: the bill's friendly_name doubles as eLMS's recordNumber,
+        # so the swap is just a URL change.
+        if "chicago.legistar.com" in url:
+            friendly_name = getattr(object, "friendly_name", "")
+            if friendly_name:
+                url = (
+                    "https://chicityclerkelms.chicago.gov/Matter/?recordNumber="
+                    + friendly_name
+                )
+        return f"<a href='{url}' target='_blank' rel='nofollow'><i class='fa fa-fw fa-link'></i> View on the {settings.CITY_VOCAB['SOURCE']} website</a>"  # noqa
 
     except ObjectDoesNotExist:
         return ""


### PR DESCRIPTION
Bills scraped from the old Legistar instance still have a `source.url` that points at `chicago.legistar.com`, which is gone now. eLMS has the same data under a `Matter` URL where `recordNumber` is just the bill's friendly_name, so I'm doing the swap inline in `get_legistar_link`.

Non-bill objects (events, persons, committees) fall through unchanged since they don't have a `friendly_name`.

Per @fgregg's question on the issue ("at the database level, or in the app"), this is the app-level approach. Happy to drop it in favor of a data fix if you'd rather rewrite `Source.url` once.

Closes #381.